### PR TITLE
Add plugin system for runtime-loaded framework providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: cmake --preset default
 
       - name: Build managed WPF assembly
-        run: msbuild src/tap_wpf/LvtWpfTap.csproj /p:Configuration=Release /restore /v:minimal
+        run: msbuild src/tap_wpf/LvtWpfTap.csproj /p:Configuration=Release /p:Platform=AnyCPU /restore /v:minimal
 
       - name: Build
         run: cmake --build build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         run: cmake --preset ${{ matrix.preset }} -DCMAKE_BUILD_TYPE=Release
 
       - name: Build managed WPF assembly
-        run: msbuild src/tap_wpf/LvtWpfTap.csproj /p:Configuration=Release /restore /v:minimal
+        run: msbuild src/tap_wpf/LvtWpfTap.csproj /p:Configuration=Release /p:Platform=AnyCPU /restore /v:minimal
 
       - name: Build
         run: cmake --build ${{ matrix.build_dir }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Build output
 build/
+build-x86/
+build-arm64/
 
 # IDE files
 .vs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(lvt
     src/tree_builder.cpp
     src/json_serializer.cpp
     src/screenshot.cpp
+    src/plugin_loader.cpp
     src/providers/win32_provider.cpp
     src/providers/comctl_provider.cpp
     src/providers/xaml_provider.cpp
@@ -104,6 +105,7 @@ add_executable(lvt_unit_tests
     src/json_serializer.cpp
     src/framework_detector.cpp
     src/target.cpp
+    src/plugin_loader.cpp
     src/providers/win32_provider.cpp
     src/providers/comctl_provider.cpp
     src/providers/xaml_provider.cpp

--- a/src/framework_detector.h
+++ b/src/framework_detector.h
@@ -11,14 +11,19 @@ enum class Framework {
     Xaml,
     WinUI3,
     Wpf,
+    Plugin,  // Plugin-provided framework (name in FrameworkInfo::name)
 };
 
 struct FrameworkInfo {
     Framework type;
     std::string version; // e.g. "3.1.7.2602" for WinUI3, "6.10" for comctl
+    std::string name;    // Plugin-provided name (empty for built-in frameworks)
 };
 
 std::string framework_to_string(Framework f);
+
+// Returns the display name for a FrameworkInfo (uses name field if set).
+std::string framework_display_name(const FrameworkInfo& fi);
 
 // Detect which UI frameworks are in use for the given window/process.
 std::vector<FrameworkInfo> detect_frameworks(HWND hwnd, DWORD pid);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include "tree_builder.h"
 #include "json_serializer.h"
 #include "screenshot.h"
+#include "plugin_loader.h"
 #include "debug.h"
 
 #include <cstdio>
@@ -111,6 +112,9 @@ int main(int argc, char* argv[]) {
 
     auto args = parse_args(argc, argv);
 
+    // Load plugins from %USERPROFILE%/.lvt/plugins/
+    lvt::load_plugins();
+
     // --dump is default unless --screenshot is specified without --dump
     if (!args.dumpSet)
         args.dump = args.screenshotFile.empty();
@@ -190,12 +194,13 @@ int main(int argc, char* argv[]) {
     if (args.frameworksOnly) {
         // Just print detected frameworks
         for (auto& fi : frameworks) {
+            auto name = lvt::framework_display_name(fi);
             if (fi.version.empty())
-                printf("%s\n", lvt::framework_to_string(fi.type).c_str());
+                printf("%s\n", name.c_str());
             else
-                printf("%s %s\n", lvt::framework_to_string(fi.type).c_str(),
-                       fi.version.c_str());
+                printf("%s %s\n", name.c_str(), fi.version.c_str());
         }
+        lvt::unload_plugins();
         return 0;
     }
 
@@ -221,10 +226,11 @@ int main(int argc, char* argv[]) {
     if (args.dump) {
         std::vector<std::string> frameworkNames;
         for (auto& fi : frameworks) {
+            auto name = lvt::framework_display_name(fi);
             if (fi.version.empty())
-                frameworkNames.push_back(lvt::framework_to_string(fi.type));
+                frameworkNames.push_back(name);
             else
-                frameworkNames.push_back(lvt::framework_to_string(fi.type) + " " + fi.version);
+                frameworkNames.push_back(name + " " + fi.version);
         }
 
         std::string serialized;
@@ -259,5 +265,6 @@ int main(int argc, char* argv[]) {
         }
     }
 
+    lvt::unload_plugins();
     return 0;
 }

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -1,0 +1,89 @@
+#pragma once
+
+// lvt plugin interface — C ABI for runtime-loaded framework provider plugins.
+// Plugins are DLLs placed in %USERPROFILE%/.lvt/plugins/ and discovered at startup.
+// This header is the ONLY dependency between lvt core and any plugin.
+
+#include <stdint.h>
+#include <Windows.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define LVT_PLUGIN_API_VERSION 1
+
+// ---------- Plugin metadata ----------
+
+struct LvtPluginInfo {
+    uint32_t struct_size;       // sizeof(LvtPluginInfo), for versioning
+    uint32_t api_version;       // must be LVT_PLUGIN_API_VERSION
+    const char* name;           // short identifier, e.g. "myframework"
+    const char* description;    // human-readable, e.g. "Custom framework support"
+};
+
+// ---------- Framework detection ----------
+
+struct LvtFrameworkDetection {
+    uint32_t struct_size;
+    const char* name;           // framework name reported by plugin
+    const char* version;        // version string or NULL
+};
+
+// ---------- Element data (C ABI mirror of lvt::Element) ----------
+
+struct LvtBounds {
+    int32_t x, y, width, height;
+};
+
+struct LvtProperty {
+    const char* key;
+    const char* value;
+};
+
+struct LvtElementData {
+    uint32_t struct_size;
+    const char* type;
+    const char* framework;
+    const char* class_name;
+    const char* text;
+    LvtBounds bounds;
+    const LvtProperty* properties;
+    uint32_t property_count;
+    struct LvtElementData* children;
+    uint32_t child_count;
+    uintptr_t native_handle;    // e.g. HWND
+};
+
+// ---------- Plugin entry points ----------
+// Plugins must export these functions by name.
+
+// Returns static plugin metadata. Called once at load time.
+typedef LvtPluginInfo* (*LvtPluginInfoFn)(void);
+
+// Detect if this plugin's framework is present in the target process.
+// Returns nonzero if detected, fills `out` with framework info.
+// `out` is caller-allocated. Plugin should set name and version fields.
+typedef int (*LvtDetectFrameworkFn)(DWORD pid, HWND hwnd, LvtFrameworkDetection* out);
+
+// Enrich the element tree with this plugin's framework data.
+// `json_out` receives a malloc'd JSON string (caller frees with lvt_plugin_free).
+// The JSON follows the same schema as the XAML TAP DLL output:
+//   [{"type":"...", "name":"...", "children":[...], "width":..., "height":..., "offsetX":..., "offsetY":...}]
+// `hwnd_filter` is the HWND of a specific host window to scope enrichment to,
+// or NULL for all.
+// Returns nonzero on success.
+typedef int (*LvtEnrichTreeFn)(HWND hwnd, DWORD pid, const char* element_class_filter, char** json_out);
+
+// Free memory allocated by the plugin (e.g. json_out from LvtEnrichTreeFn).
+typedef void (*LvtPluginFreeFn)(void* ptr);
+
+// Exported function names (for GetProcAddress)
+#define LVT_PLUGIN_INFO_FUNC      "lvt_plugin_info"
+#define LVT_PLUGIN_DETECT_FUNC    "lvt_detect_framework"
+#define LVT_PLUGIN_ENRICH_FUNC    "lvt_enrich_tree"
+#define LVT_PLUGIN_FREE_FUNC      "lvt_plugin_free"
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/plugin_loader.cpp
+++ b/src/plugin_loader.cpp
@@ -1,0 +1,239 @@
+#include "plugin_loader.h"
+#include "debug.h"
+#include <nlohmann/json.hpp>
+#include <cstdio>
+#include <cstdlib>
+#include <functional>
+#include <userenv.h>
+
+#pragma comment(lib, "userenv.lib")
+
+using json = nlohmann::json;
+
+namespace lvt {
+
+static std::vector<LoadedPlugin> s_plugins;
+
+static std::wstring get_plugins_dir() {
+    wchar_t profileDir[MAX_PATH]{};
+    DWORD size = MAX_PATH;
+    if (!GetEnvironmentVariableW(L"USERPROFILE", profileDir, size))
+        return {};
+    return std::wstring(profileDir) + L"\\.lvt\\plugins";
+}
+
+void load_plugins() {
+    auto dir = get_plugins_dir();
+    if (dir.empty()) return;
+
+    std::wstring pattern = dir + L"\\*.dll";
+    WIN32_FIND_DATAW fd;
+    HANDLE hFind = FindFirstFileW(pattern.c_str(), &fd);
+    if (hFind == INVALID_HANDLE_VALUE) return;
+
+    do {
+        if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) continue;
+
+        std::wstring fullPath = dir + L"\\" + fd.cFileName;
+        HMODULE mod = LoadLibraryW(fullPath.c_str());
+        if (!mod) {
+            if (g_debug)
+                fprintf(stderr, "lvt: failed to load plugin %ls (error %lu)\n",
+                        fd.cFileName, GetLastError());
+            continue;
+        }
+
+        auto infoFn = reinterpret_cast<LvtPluginInfoFn>(
+            GetProcAddress(mod, LVT_PLUGIN_INFO_FUNC));
+        if (!infoFn) {
+            if (g_debug)
+                fprintf(stderr, "lvt: %ls has no %s export, skipping\n",
+                        fd.cFileName, LVT_PLUGIN_INFO_FUNC);
+            FreeLibrary(mod);
+            continue;
+        }
+
+        LvtPluginInfo* info = infoFn();
+        if (!info || info->struct_size < sizeof(LvtPluginInfo) ||
+            info->api_version != LVT_PLUGIN_API_VERSION) {
+            if (g_debug)
+                fprintf(stderr, "lvt: %ls has incompatible plugin API version\n",
+                        fd.cFileName);
+            FreeLibrary(mod);
+            continue;
+        }
+
+        LoadedPlugin lp{};
+        lp.module = mod;
+        lp.info = info;
+        lp.detect = reinterpret_cast<LvtDetectFrameworkFn>(
+            GetProcAddress(mod, LVT_PLUGIN_DETECT_FUNC));
+        lp.enrich = reinterpret_cast<LvtEnrichTreeFn>(
+            GetProcAddress(mod, LVT_PLUGIN_ENRICH_FUNC));
+        lp.free_fn = reinterpret_cast<LvtPluginFreeFn>(
+            GetProcAddress(mod, LVT_PLUGIN_FREE_FUNC));
+
+        if (g_debug)
+            fprintf(stderr, "lvt: loaded plugin '%s' (%s)\n",
+                    info->name ? info->name : "?",
+                    info->description ? info->description : "");
+
+        s_plugins.push_back(lp);
+    } while (FindNextFileW(hFind, &fd));
+
+    FindClose(hFind);
+}
+
+void unload_plugins() {
+    for (auto& p : s_plugins) {
+        FreeLibrary(p.module);
+    }
+    s_plugins.clear();
+}
+
+const std::vector<LoadedPlugin>& get_plugins() {
+    return s_plugins;
+}
+
+std::vector<PluginFrameworkInfo> detect_plugin_frameworks(HWND hwnd, DWORD pid) {
+    std::vector<PluginFrameworkInfo> result;
+    for (auto& p : s_plugins) {
+        if (!p.detect) continue;
+        LvtFrameworkDetection det{};
+        det.struct_size = sizeof(det);
+        if (p.detect(pid, hwnd, &det)) {
+            PluginFrameworkInfo pfi;
+            pfi.name = det.name ? det.name : p.info->name;
+            pfi.version = det.version ? det.version : "";
+            pfi.plugin = &p;
+            result.push_back(std::move(pfi));
+            if (g_debug)
+                fprintf(stderr, "lvt: plugin '%s' detected framework '%s' %s\n",
+                        p.info->name, pfi.name.c_str(), pfi.version.c_str());
+        }
+    }
+    return result;
+}
+
+// Strip control characters (same as sanitize in xaml_diag_common.cpp)
+static std::string sanitize(const std::string& s) {
+    std::string r;
+    r.reserve(s.size());
+    for (char c : s) {
+        if (static_cast<unsigned char>(c) >= 0x20 || c == '\t')
+            r += c;
+    }
+    return r;
+}
+
+// Recursively graft JSON nodes into an Element tree.
+static void graft_json_node(const json& j, Element& parent, const std::string& framework,
+                            double parentOffsetX = 0, double parentOffsetY = 0) {
+    Element el;
+    el.framework = framework;
+    el.className = sanitize(j.value("type", ""));
+    el.text = sanitize(j.value("name", ""));
+
+    auto lastDot = el.className.rfind('.');
+    el.type = (lastDot != std::string::npos) ? el.className.substr(lastDot + 1) : el.className;
+
+    double ox = j.value("offsetX", 0.0);
+    double oy = j.value("offsetY", 0.0);
+    double w = j.value("width", 0.0);
+    double h = j.value("height", 0.0);
+    double absX = parentOffsetX + ox;
+    double absY = parentOffsetY + oy;
+    if (w > 0 && h > 0) {
+        el.bounds.x = static_cast<int>(absX);
+        el.bounds.y = static_cast<int>(absY);
+        el.bounds.width = static_cast<int>(w);
+        el.bounds.height = static_cast<int>(h);
+    }
+
+    // Copy additional properties if present
+    if (j.contains("properties") && j["properties"].is_object()) {
+        for (auto& [key, val] : j["properties"].items()) {
+            el.properties[key] = val.is_string() ? val.get<std::string>() : val.dump();
+        }
+    }
+
+    if (j.contains("children") && j["children"].is_array()) {
+        for (auto& child : j["children"]) {
+            graft_json_node(child, el, framework, absX, absY);
+        }
+    }
+
+    parent.children.push_back(std::move(el));
+}
+
+bool enrich_with_plugin(Element& root, HWND hwnd, DWORD pid,
+                        const PluginFrameworkInfo& pluginFw) {
+    if (!pluginFw.plugin || !pluginFw.plugin->enrich) return false;
+
+    char* jsonOut = nullptr;
+    int ok = pluginFw.plugin->enrich(hwnd, pid, nullptr, &jsonOut);
+    if (!ok || !jsonOut) return false;
+
+    json treeJson;
+    try {
+        treeJson = json::parse(jsonOut);
+    } catch (const json::parse_error& e) {
+        fprintf(stderr, "lvt: failed to parse plugin JSON: %s\n", e.what());
+        if (pluginFw.plugin->free_fn) pluginFw.plugin->free_fn(jsonOut);
+        return false;
+    }
+
+    if (g_debug)
+        fprintf(stderr, "lvt: plugin '%s' returned %zu bytes of tree data\n",
+                pluginFw.name.c_str(), strlen(jsonOut));
+
+    if (pluginFw.plugin->free_fn) pluginFw.plugin->free_fn(jsonOut);
+
+    // The plugin JSON is an array of tree roots. Each root has a "target_hwnd"
+    // field (hex HWND string) indicating which existing element to graft under.
+    // We walk the tree fresh for each root to find the matching host element by
+    // its "hwnd" property, avoiding stale pointers from vector reallocations.
+    if (treeJson.is_array()) {
+        for (auto& node : treeJson) {
+            std::string targetHwnd = node.value("target_hwnd", "");
+
+            // Find the element whose "hwnd" property matches target_hwnd
+            Element* host = nullptr;
+            if (!targetHwnd.empty()) {
+                std::function<Element*(Element&)> findHost = [&](Element& el) -> Element* {
+                    auto it = el.properties.find("hwnd");
+                    if (it != el.properties.end() && it->second == targetHwnd)
+                        return &el;
+                    for (auto& child : el.children) {
+                        auto* found = findHost(child);
+                        if (found) return found;
+                    }
+                    return nullptr;
+                };
+                host = findHost(root);
+            }
+
+            if (host) {
+                double baseX = host->bounds.x;
+                double baseY = host->bounds.y;
+                if (node.contains("children") && node["children"].is_array()) {
+                    for (auto& child : node["children"]) {
+                        graft_json_node(child, *host, pluginFw.name, baseX, baseY);
+                    }
+                } else {
+                    graft_json_node(node, *host, pluginFw.name, baseX, baseY);
+                }
+            } else {
+                // No matching host — graft under root
+                graft_json_node(node, root, pluginFw.name,
+                                root.bounds.x, root.bounds.y);
+            }
+        }
+    } else if (treeJson.is_object()) {
+        graft_json_node(treeJson, root, pluginFw.name);
+    }
+
+    return true;
+}
+
+} // namespace lvt

--- a/src/plugin_loader.h
+++ b/src/plugin_loader.h
@@ -1,0 +1,41 @@
+#pragma once
+#include "plugin.h"
+#include "element.h"
+#include <string>
+#include <vector>
+#include <Windows.h>
+
+namespace lvt {
+
+struct LoadedPlugin {
+    HMODULE module;
+    LvtPluginInfo* info;
+    LvtDetectFrameworkFn detect;
+    LvtEnrichTreeFn enrich;
+    LvtPluginFreeFn free_fn;
+};
+
+// Discover and load plugins from %USERPROFILE%/.lvt/plugins/
+void load_plugins();
+
+// Unload all loaded plugins.
+void unload_plugins();
+
+// Returns the list of loaded plugins.
+const std::vector<LoadedPlugin>& get_plugins();
+
+struct PluginFrameworkInfo {
+    std::string name;
+    std::string version;
+    const LoadedPlugin* plugin;
+};
+
+// Ask all loaded plugins to detect frameworks in the given process.
+std::vector<PluginFrameworkInfo> detect_plugin_frameworks(HWND hwnd, DWORD pid);
+
+// Ask the relevant plugin to enrich the tree for a plugin-detected framework.
+// Parses the JSON response and grafts elements under matching Win32 nodes.
+bool enrich_with_plugin(Element& root, HWND hwnd, DWORD pid,
+                        const PluginFrameworkInfo& pluginFw);
+
+} // namespace lvt

--- a/src/tree_builder.cpp
+++ b/src/tree_builder.cpp
@@ -5,6 +5,7 @@
 #include "providers/xaml_provider.h"
 #include "providers/winui3_provider.h"
 #include "providers/wpf_provider.h"
+#include "plugin_loader.h"
 #include <algorithm>
 #include <memory>
 
@@ -62,6 +63,20 @@ Element build_tree(HWND hwnd, DWORD pid, const std::vector<FrameworkInfo>& frame
         case Framework::Wpf: {
             WpfProvider wpf;
             wpf.enrich(root, hwnd, pid);
+            break;
+        }
+        case Framework::Plugin: {
+            // Look up the plugin by name and enrich
+            for (auto& p : get_plugins()) {
+                if (p.info && p.info->name && fi.name == p.info->name) {
+                    PluginFrameworkInfo pf;
+                    pf.name = fi.name;
+                    pf.version = fi.version;
+                    pf.plugin = &p;
+                    enrich_with_plugin(root, hwnd, pid, pf);
+                    break;
+                }
+            }
             break;
         }
         default:


### PR DESCRIPTION
Add a generic plugin architecture that allows external DLLs to extend lvt with additional UI framework support.

## What this does

Plugins are DLLs placed in \%USERPROFILE%/.lvt/plugins/\ and discovered at startup. Each plugin exports C ABI functions to detect frameworks and enrich the element tree with additional subtrees.

## Core changes

- **plugin.h**: C ABI plugin interface with versioning
- **plugin_loader.h/cpp**: Plugin discovery, loading, framework detection delegation, and JSON-based tree grafting
- **framework_detector**: Added \Framework::Plugin\ enum with string name field
- **tree_builder**: Calls \nrich_with_plugin()\ for plugin-detected frameworks
- **main.cpp**: Plugin load/unload lifecycle

## Plugin contract

Plugins export:
- \lvt_plugin_info()\ — metadata (name, version, API version)
- \lvt_detect_framework()\ — detect if the plugin's framework is present
- \lvt_enrich_tree()\ — return JSON tree data to graft into the element tree
- \lvt_plugin_free()\ — free allocated memory

JSON tree roots specify a \	arget_hwnd\ field to indicate which existing Win32 element to graft under.

## Tests

11 new tests (44 total, all passing):
- 8 PluginGraft tests (HWND matching, fallback, multiple roots, nested children, properties, error handling)
- 3 FrameworkDisplayName tests