### PR TITLE
Build: select cppwinrt from the active/newest Windows SDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,12 +59,33 @@ endif()
 set(WINUI3_CPPWINRT_DIR "${CMAKE_SOURCE_DIR}/src/tap/winui3")
 set(WINUI3_CPPWINRT_STAMP "${WINUI3_CPPWINRT_DIR}/winrt/Microsoft.UI.Xaml.h")
 if(NOT EXISTS "${WINUI3_CPPWINRT_STAMP}")
-    # Find cppwinrt.exe from Windows SDK
-    find_program(CPPWINRT_EXE cppwinrt
-        HINTS "$ENV{WindowsSdkDir}/bin/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/x64"
-              "$ENV{WindowsSdkDir}/bin/10.0.22621.0/x64"
-              "C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x64"
-    )
+    # Find cppwinrt.exe from the *active* Windows SDK. The generated projection
+    # embeds the cppwinrt version and is checked (via static_assert) against the
+    # <winrt/base.h> on the compiler's INCLUDE path. Hardcoding an SDK version
+    # breaks on machines whose active/newest SDK differs from that version
+    # ("Mismatched C++/WinRT headers"), so prefer the SDK selected by the current
+    # developer command prompt and fall back to the newest installed SDK.
+    set(_cppwinrt_hints "")
+    # 1. Exact versioned bin dir of the active SDK (set by the VS dev prompt).
+    if(DEFINED ENV{WindowsSdkVerBinPath})
+        list(APPEND _cppwinrt_hints "$ENV{WindowsSdkVerBinPath}/x64")
+    endif()
+    # 2. Compose from WindowsSdkDir + WindowsSDKVersion (may have a trailing slash).
+    if(DEFINED ENV{WindowsSdkDir} AND DEFINED ENV{WindowsSDKVersion})
+        string(REGEX REPLACE "[\\/]+$" "" _lvt_sdk_ver "$ENV{WindowsSDKVersion}")
+        list(APPEND _cppwinrt_hints "$ENV{WindowsSdkDir}/bin/${_lvt_sdk_ver}/x64")
+    endif()
+    # 3. Fall back to the newest installed Windows 10/11 SDK bin dir.
+    file(GLOB _lvt_sdk_bin_dirs
+        "$ENV{WindowsSdkDir}/bin/10.*"
+        "C:/Program Files (x86)/Windows Kits/10/bin/10.*")
+    list(SORT _lvt_sdk_bin_dirs ORDER DESCENDING)
+    foreach(_lvt_bin ${_lvt_sdk_bin_dirs})
+        if(IS_DIRECTORY "${_lvt_bin}")
+            list(APPEND _cppwinrt_hints "${_lvt_bin}/x64")
+        endif()
+    endforeach()
+    find_program(CPPWINRT_EXE cppwinrt HINTS ${_cppwinrt_hints})
     if(NOT CPPWINRT_EXE)
         # Fallback: search PATH
         find_program(CPPWINRT_EXE cppwinrt)


### PR DESCRIPTION
## Problem

Building the TAP DLL fails on this machine (and any machine whose active/newest Windows SDK differs from 10.0.22621.0) with:

```
error C2338: static assertion failed: 'Mismatched C++/WinRT headers.'
```

The generated C++/WinRT projection under `src/tap/winui3/winrt/` embeds the cppwinrt version and is validated (via `static_assert`) against `<winrt/base.h>` on the compiler's `INCLUDE` path. CMake hardcoded `10.0.22621.0` when locating `cppwinrt.exe`, so on a dev prompt using e.g. SDK 10.0.26100.0 the projection (`2.0.220110.5`) mismatched `base.h` (`2.0.250303.5`).

Under the Ninja generator `CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION` is empty, so the only effective hint was the hardcoded 22621 path.

## Fix

Resolve `cppwinrt.exe` from the SDK selected by the current developer command prompt:
1. `%WindowsSdkVerBinPath%\x64` (exact active versioned bin dir)
2. `%WindowsSdkDir%\bin\%WindowsSDKVersion%\x64` (trailing slash trimmed)
3. newest installed `10.*` SDK bin dir
4. PATH

This makes the generated projection always match the `base.h` the compiler uses.

## Validation

Fresh clean configure + build on SDK 10.0.26100.0:
- projection regenerated as `2.0.250303.5` (matches `base.h`)
- full C++ build green (`lvt.exe`, `lvt_tap_x64.dll`, `lvt_wpf_tap_x64.dll`, chromium plugin)
- unit tests: **47 passed**
- chromium tests: **11 passed**
- integration tests: **21 passed** (1 conditional skip)

No behavior change on machines where 22621 happened to be correct.
