### PR TITLE
Add --query for element property lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ lvt --hwnd 0x1A0B3C --frameworks
 # Scope to a subtree
 lvt --name myapp --element e5 --depth 3
 
+# Query one element property
+lvt --name notepad --query e2 text
+
 # Screenshot + tree dump together
 lvt --name notepad --screenshot out.png --dump
 ```
@@ -90,6 +93,7 @@ lvt --name notepad --screenshot out.png --dump
 | `--screenshot <file>` | Capture annotated screenshot to PNG |
 | `--dump` | Output the tree (default unless `--screenshot` is used) |
 | `--element <id>` | Scope to a specific element subtree |
+| `--query <id> [property]` | Output one element's properties, or a single property value |
 | `--frameworks` | Just list detected frameworks |
 | `--depth <n>` | Max tree traversal depth |
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <string>
 #include <fstream>
+#include <sstream>
 #include <nlohmann/json.hpp>
 
 static void print_usage() {
@@ -36,6 +37,7 @@ static void print_usage() {
 #endif
         "  --dump               Output the tree (default; implied unless --screenshot)\n"
         "  --element <id>       Scope to a specific element subtree\n"
+        "  --query <id> [prop]  Output one element's properties or a single property\n"
         "  --frameworks         Just detect and list frameworks\n"
         "  --depth <n>          Max tree traversal depth (default: unlimited)\n"
         "  --debug              Show verbose diagnostic output\n"
@@ -55,6 +57,8 @@ struct Args {
     std::string annotationsFile;
 #endif
     std::string elementId;
+    std::string queryId;
+    std::string queryProperty;
     int depth = -1;
     bool frameworksOnly = false;
     bool dump = false;      // explicitly requested via --dump
@@ -88,6 +92,15 @@ static Args parse_args(int argc, char* argv[]) {
 #endif
         } else if (strcmp(argv[i], "--element") == 0 && i + 1 < argc) {
             args.elementId = argv[++i];
+        } else if (strcmp(argv[i], "--query") == 0) {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "lvt: --query requires an element id\n");
+                exit(1);
+            }
+            args.queryId = argv[++i];
+            if (i + 1 < argc && strncmp(argv[i + 1], "--", 2) != 0) {
+                args.queryProperty = argv[++i];
+            }
         } else if (strcmp(argv[i], "--depth") == 0 && i + 1 < argc) {
             args.depth = atoi(argv[++i]);
         } else if (strcmp(argv[i], "--frameworks") == 0) {
@@ -106,13 +119,68 @@ static Args parse_args(int argc, char* argv[]) {
     return args;
 }
 
-static lvt::Element* find_element(lvt::Element& root, const std::string& id) {
-    if (root.id == id) return &root;
-    for (auto& child : root.children) {
-        auto* found = find_element(child, id);
-        if (found) return found;
+static std::string xml_escape(const std::string& s) {
+    std::string r;
+    r.reserve(s.size());
+    for (char c : s) {
+        switch (c) {
+        case '&':  r += "&amp;";  break;
+        case '<':  r += "&lt;";   break;
+        case '>':  r += "&gt;";   break;
+        case '"':  r += "&quot;"; break;
+        case '\'': r += "&apos;"; break;
+        default:
+            if (static_cast<unsigned char>(c) >= 0x20)
+                r += c;
+        }
     }
-    return nullptr;
+    return r;
+}
+
+static nlohmann::json query_element_to_json(const lvt::Element& element) {
+    nlohmann::json j;
+    j["id"] = element.id;
+    j["type"] = element.type;
+    j["framework"] = element.framework;
+    j["className"] = element.className;
+    j["text"] = element.text;
+    j["bounds"] = lvt::get_element_property(element, "bounds").value();
+    for (auto& [key, value] : element.properties) {
+        j[key] = value;
+    }
+    return j;
+}
+
+static std::string query_element_to_xml(const lvt::Element& element) {
+    std::ostringstream out;
+    out << "<Element";
+    out << " id=\"" << xml_escape(element.id) << "\"";
+    out << " type=\"" << xml_escape(element.type) << "\"";
+    out << " framework=\"" << xml_escape(element.framework) << "\"";
+    out << " className=\"" << xml_escape(element.className) << "\"";
+    out << " text=\"" << xml_escape(element.text) << "\"";
+    out << " bounds=\"" << xml_escape(lvt::get_element_property(element, "bounds").value()) << "\"";
+    for (auto& [key, value] : element.properties) {
+        out << " " << xml_escape(key) << "=\"" << xml_escape(value) << "\"";
+    }
+    out << " />\n";
+    return out.str();
+}
+
+static bool write_output(const std::string& outputFile, const std::string& content) {
+    if (outputFile.empty()) {
+        printf("%s\n", content.c_str());
+        return true;
+    }
+    std::ofstream out(outputFile);
+    if (!out) {
+        fprintf(stderr, "lvt: cannot write to '%s'\n", outputFile.c_str());
+        return false;
+    }
+    out << content << "\n";
+    if (lvt::g_debug)
+        fprintf(stderr, "lvt: wrote output to %s\n", outputFile.c_str());
+    return true;
 }
 
 int main(int argc, char* argv[]) {
@@ -221,11 +289,41 @@ int main(int argc, char* argv[]) {
     // Scope to element if requested
     lvt::Element* outputRoot = &tree;
     if (!args.elementId.empty()) {
-        outputRoot = find_element(tree, args.elementId);
+        outputRoot = lvt::find_element_by_id(tree, args.elementId);
         if (!outputRoot) {
             fprintf(stderr, "lvt: element '%s' not found\n", args.elementId.c_str());
             return 1;
         }
+    }
+
+    if (!args.queryId.empty()) {
+        auto* queryElement = lvt::find_element_by_id(tree, args.queryId);
+        if (!queryElement) {
+            fprintf(stderr, "lvt: element '%s' not found\n", args.queryId.c_str());
+            return 1;
+        }
+
+        std::string queryOutput;
+        if (!args.queryProperty.empty()) {
+            auto value = lvt::get_element_property(*queryElement, args.queryProperty);
+            if (!value) {
+                fprintf(stderr, "lvt: property '%s' not found on element '%s'\n",
+                        args.queryProperty.c_str(), args.queryId.c_str());
+                return 1;
+            }
+            queryOutput = *value;
+        } else if (args.format == "xml") {
+            queryOutput = query_element_to_xml(*queryElement);
+            if (!queryOutput.empty() && queryOutput.back() == '\n')
+                queryOutput.pop_back();
+        } else {
+            queryOutput = query_element_to_json(*queryElement).dump(2);
+        }
+
+        if (!write_output(args.outputFile, queryOutput))
+            return 1;
+        lvt::unload_plugins();
+        return 0;
     }
 
     // Apply depth limit relative to the output root
@@ -253,18 +351,8 @@ int main(int argc, char* argv[]) {
                                                  target.processName, frameworkNames);
         }
 
-        if (args.outputFile.empty()) {
-            printf("%s\n", serialized.c_str());
-        } else {
-            std::ofstream out(args.outputFile);
-            if (!out) {
-                fprintf(stderr, "lvt: cannot write to '%s'\n", args.outputFile.c_str());
-                return 1;
-            }
-            out << serialized << "\n";
-            if (lvt::g_debug)
-                fprintf(stderr, "lvt: wrote tree to %s\n", args.outputFile.c_str());
-        }
+        if (!write_output(args.outputFile, serialized))
+            return 1;
     }
 
     // Screenshot

--- a/src/tree_builder.cpp
+++ b/src/tree_builder.cpp
@@ -8,6 +8,7 @@
 #include "plugin_loader.h"
 #include <algorithm>
 #include <memory>
+#include <sstream>
 
 namespace lvt {
 
@@ -31,6 +32,42 @@ static void trim_to_depth_impl(Element& el, int currentDepth, int maxDepth) {
 void assign_element_ids(Element& root) {
     int counter = 0;
     assign_ids_recursive(root, counter);
+}
+
+Element* find_element_by_id(Element& root, const std::string& id) {
+    if (root.id == id) return &root;
+    for (auto& child : root.children) {
+        auto* found = find_element_by_id(child, id);
+        if (found) return found;
+    }
+    return nullptr;
+}
+
+const Element* find_element_by_id(const Element& root, const std::string& id) {
+    if (root.id == id) return &root;
+    for (auto& child : root.children) {
+        auto* found = find_element_by_id(child, id);
+        if (found) return found;
+    }
+    return nullptr;
+}
+
+std::optional<std::string> get_element_property(const Element& element, const std::string& property) {
+    if (property == "id") return element.id;
+    if (property == "type") return element.type;
+    if (property == "framework") return element.framework;
+    if (property == "className") return element.className;
+    if (property == "text") return element.text;
+    if (property == "bounds") {
+        std::ostringstream out;
+        out << element.bounds.x << "," << element.bounds.y << ","
+            << element.bounds.width << "," << element.bounds.height;
+        return out.str();
+    }
+
+    auto it = element.properties.find(property);
+    if (it != element.properties.end()) return it->second;
+    return std::nullopt;
 }
 
 void trim_to_depth(Element& root, int maxDepth) {

--- a/src/tree_builder.h
+++ b/src/tree_builder.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "element.h"
 #include "framework_detector.h"
+#include <optional>
+#include <string>
 #include <vector>
 
 namespace lvt {
@@ -10,6 +12,13 @@ Element build_tree(HWND hwnd, DWORD pid, const std::vector<FrameworkInfo>& frame
 
 // Assign deterministic element IDs (e0, e1, ...) in depth-first order.
 void assign_element_ids(Element& root);
+
+// Find an element by its assigned ID.
+Element* find_element_by_id(Element& root, const std::string& id);
+const Element* find_element_by_id(const Element& root, const std::string& id);
+
+// Return a built-in or dynamic element property value.
+std::optional<std::string> get_element_property(const Element& element, const std::string& property);
 
 // Trim element tree to a maximum depth (0 = root only, 1 = root + children, etc.)
 void trim_to_depth(Element& root, int maxDepth);

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -12,6 +12,8 @@
 using json = nlohmann::json;
 using namespace lvt;
 
+static Element make_test_tree();
+
 // ---- Element ID assignment ----
 
 TEST(AssignElementIds, SingleElement) {
@@ -59,6 +61,45 @@ TEST(AssignElementIds, DeepTree) {
     EXPECT_EQ(root.children[0].id, "e1");
     EXPECT_EQ(root.children[0].children[0].id, "e2");
     EXPECT_EQ(root.children[0].children[0].children[0].id, "e3");
+}
+
+TEST(ElementLookup, FindsElementById) {
+    auto root = make_test_tree();
+
+    auto* found = find_element_by_id(root, "e1");
+
+    ASSERT_NE(found, nullptr);
+    EXPECT_EQ(found->type, "Button");
+    EXPECT_EQ(found->text, "OK");
+}
+
+TEST(ElementLookup, ReturnsNullForUnknownId) {
+    auto root = make_test_tree();
+
+    EXPECT_EQ(find_element_by_id(root, "missing"), nullptr);
+}
+
+TEST(ElementPropertyLookup, BuiltInProperties) {
+    auto root = make_test_tree();
+
+    EXPECT_EQ(get_element_property(root, "id"), "e0");
+    EXPECT_EQ(get_element_property(root, "type"), "Window");
+    EXPECT_EQ(get_element_property(root, "framework"), "win32");
+    EXPECT_EQ(get_element_property(root, "className"), "MyWindow");
+    EXPECT_EQ(get_element_property(root, "text"), "Hello");
+    EXPECT_EQ(get_element_property(root, "bounds"), "100,200,800,600");
+}
+
+TEST(ElementPropertyLookup, DynamicProperty) {
+    auto root = make_test_tree();
+
+    EXPECT_EQ(get_element_property(root, "visible"), "true");
+}
+
+TEST(ElementPropertyLookup, UnknownProperty) {
+    auto root = make_test_tree();
+
+    EXPECT_EQ(get_element_property(root, "missing"), std::nullopt);
 }
 
 // ---- framework_to_string ----


### PR DESCRIPTION
Adds --query <id> [property] to print a selected element's properties or a single property value, reusing tree lookup helpers and covering lookup/error cases with unit tests.

Fixes #15