### PR TITLE
Add --watch mode with live tree diffing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(lvt
     src/framework_detector.cpp
     src/tree_builder.cpp
     src/json_serializer.cpp
+    src/watch_diff.cpp
     src/screenshot.cpp
     src/plugin_loader.cpp
     src/providers/win32_provider.cpp
@@ -264,6 +265,7 @@ add_executable(lvt_unit_tests
     tests/unit_tests.cpp
     src/tree_builder.cpp
     src/json_serializer.cpp
+    src/watch_diff.cpp
     src/framework_detector.cpp
     src/target.cpp
     src/plugin_loader.cpp

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ lvt --name myapp --element e5 --depth 3
 
 # Screenshot + tree dump together
 lvt --name notepad --screenshot out.png --dump
+
+# Watch for live tree changes as JSON diff events
+lvt --name notepad --watch --interval 250
 ```
 
 ### Options
@@ -89,11 +92,22 @@ lvt --name notepad --screenshot out.png --dump
 | `--format <fmt>` | `json` (default) or `xml` |
 | `--screenshot <file>` | Capture annotated screenshot to PNG |
 | `--dump` | Output the tree (default unless `--screenshot` is used) |
+| `--watch` | Emit live JSON tree diff events until Ctrl+C |
+| `--interval <ms>` | Polling interval for `--watch` (default: 500) |
 | `--element <id>` | Scope to a specific element subtree |
 | `--frameworks` | Just list detected frameworks |
 | `--depth <n>` | Max tree traversal depth |
 
 ## Output format
+
+### Watch mode
+
+`--watch` repeatedly rebuilds the target tree and writes newline-delimited JSON
+events to stdout. The first tick emits the current tree as `added` events; later
+ticks emit `added`, `removed`, and `changed` events with old/new field values.
+Element matching uses stable framework/type/class/path-derived keys instead of
+the positional `e0`, `e1`, ... ids, so unique moved elements are reported as
+`changed` events with a `path` field change.
 
 ### JSON
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include "framework_detector.h"
 #include "tree_builder.h"
 #include "json_serializer.h"
+#include "watch_diff.h"
 #include "screenshot.h"
 #include "plugin_loader.h"
 #include "debug.h"
@@ -12,6 +13,22 @@
 #include <string>
 #include <fstream>
 #include <nlohmann/json.hpp>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+static std::atomic_bool g_watchStop = false;
+
+static BOOL WINAPI console_ctrl_handler(DWORD ctrlType) {
+    if (ctrlType == CTRL_C_EVENT || ctrlType == CTRL_BREAK_EVENT ||
+        ctrlType == CTRL_CLOSE_EVENT || ctrlType == CTRL_LOGOFF_EVENT ||
+        ctrlType == CTRL_SHUTDOWN_EVENT) {
+        g_watchStop = true;
+        return TRUE;
+    }
+    return FALSE;
+}
 
 static void print_usage() {
     fprintf(stderr,
@@ -35,6 +52,8 @@ static void print_usage() {
         "  --annotations-json <file>  Write annotation rectangles as JSON (test hook)\n"
 #endif
         "  --dump               Output the tree (default; implied unless --screenshot)\n"
+        "  --watch              Emit live JSON tree diff events until Ctrl+C\n"
+        "  --interval <ms>      Watch polling interval (default: 500)\n"
         "  --element <id>       Scope to a specific element subtree\n"
         "  --frameworks         Just detect and list frameworks\n"
         "  --depth <n>          Max tree traversal depth (default: unlimited)\n"
@@ -56,9 +75,11 @@ struct Args {
 #endif
     std::string elementId;
     int depth = -1;
+    int intervalMs = 500;
     bool frameworksOnly = false;
     bool dump = false;      // explicitly requested via --dump
     bool dumpSet = false;   // true if --dump was passed on command line
+    bool watch = false;
 };
 
 static Args parse_args(int argc, char* argv[]) {
@@ -90,6 +111,10 @@ static Args parse_args(int argc, char* argv[]) {
             args.elementId = argv[++i];
         } else if (strcmp(argv[i], "--depth") == 0 && i + 1 < argc) {
             args.depth = atoi(argv[++i]);
+        } else if (strcmp(argv[i], "--watch") == 0) {
+            args.watch = true;
+        } else if (strcmp(argv[i], "--interval") == 0 && i + 1 < argc) {
+            args.intervalMs = atoi(argv[++i]);
         } else if (strcmp(argv[i], "--frameworks") == 0) {
             args.frameworksOnly = true;
         } else if (strcmp(argv[i], "--dump") == 0) {
@@ -115,6 +140,78 @@ static lvt::Element* find_element(lvt::Element& root, const std::string& id) {
     return nullptr;
 }
 
+static std::vector<std::string> framework_names(const std::vector<lvt::FrameworkInfo>& frameworks) {
+    std::vector<std::string> names;
+    for (auto& fi : frameworks) {
+        auto name = lvt::framework_display_name(fi);
+        if (fi.version.empty())
+            names.push_back(name);
+        else
+            names.push_back(name + " " + fi.version);
+    }
+    return names;
+}
+
+static bool build_output_tree(const lvt::TargetInfo& target, const Args& args,
+                              lvt::Element& outputTree) {
+    auto frameworks = lvt::detect_frameworks(target.hwnd, target.pid);
+    auto tree = lvt::build_tree(target.hwnd, target.pid, frameworks);
+
+    lvt::Element* outputRoot = &tree;
+    if (!args.elementId.empty()) {
+        outputRoot = find_element(tree, args.elementId);
+        if (!outputRoot) {
+            fprintf(stderr, "lvt: element '%s' not found\n", args.elementId.c_str());
+            return false;
+        }
+    }
+
+    if (args.depth >= 0)
+        lvt::trim_to_depth(*outputRoot, args.depth);
+
+    outputTree = *outputRoot;
+    return true;
+}
+
+static int run_watch_loop(const lvt::TargetInfo& target, const Args& args) {
+    SetConsoleCtrlHandler(console_ctrl_handler, TRUE);
+
+    lvt::Element previous;
+    if (!build_output_tree(target, args, previous))
+        return 1;
+
+    for (const auto& event : lvt::snapshot_added_events(previous))
+        printf("%s\n", lvt::serialize_change_event(event).c_str());
+    fflush(stdout);
+
+    while (!g_watchStop) {
+        auto sleepUntil = std::chrono::steady_clock::now() +
+                          std::chrono::milliseconds(args.intervalMs);
+        while (!g_watchStop && std::chrono::steady_clock::now() < sleepUntil) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+        if (g_watchStop)
+            break;
+
+        if (!IsWindow(target.hwnd)) {
+            fprintf(stderr, "lvt: target window closed\n");
+            break;
+        }
+
+        lvt::Element current;
+        if (!build_output_tree(target, args, current))
+            return 1;
+
+        for (const auto& event : lvt::diff_trees(previous, current))
+            printf("%s\n", lvt::serialize_change_event(event).c_str());
+        fflush(stdout);
+        previous = std::move(current);
+    }
+
+    SetConsoleCtrlHandler(console_ctrl_handler, FALSE);
+    return 0;
+}
+
 int main(int argc, char* argv[]) {
     if (argc < 2) {
         print_usage();
@@ -129,6 +226,15 @@ int main(int argc, char* argv[]) {
     // --dump is default unless --screenshot is specified without --dump
     if (!args.dumpSet)
         args.dump = args.screenshotFile.empty();
+
+    if (args.intervalMs <= 0) {
+        fprintf(stderr, "lvt: --interval must be greater than 0\n");
+        return 1;
+    }
+    if (args.watch && args.format != "json") {
+        fprintf(stderr, "lvt: --watch emits JSON events; --format must be json\n");
+        return 1;
+    }
 
     if (!args.hwnd && !args.pid && args.processName.empty() && args.windowTitle.empty()) {
         fprintf(stderr, "lvt: must specify --hwnd, --pid, --name, or --title\n");
@@ -215,6 +321,12 @@ int main(int argc, char* argv[]) {
         return 0;
     }
 
+    if (args.watch) {
+        auto result = run_watch_loop(target, args);
+        lvt::unload_plugins();
+        return result;
+    }
+
     // Build full tree (no depth limit) so element IDs are stable
     auto tree = lvt::build_tree(target.hwnd, target.pid, frameworks);
 
@@ -235,15 +347,7 @@ int main(int argc, char* argv[]) {
 
     // Serialize and output tree (unless suppressed by --screenshot without --dump)
     if (args.dump) {
-        std::vector<std::string> frameworkNames;
-        for (auto& fi : frameworks) {
-            auto name = lvt::framework_display_name(fi);
-            if (fi.version.empty())
-                frameworkNames.push_back(name);
-            else
-                frameworkNames.push_back(name + " " + fi.version);
-        }
-
+        auto frameworkNames = framework_names(frameworks);
         std::string serialized;
         if (args.format == "xml") {
             serialized = lvt::serialize_to_xml(*outputRoot, target.hwnd, target.pid,

--- a/src/watch_diff.cpp
+++ b/src/watch_diff.cpp
@@ -1,0 +1,247 @@
+#include "watch_diff.h"
+#include <nlohmann/json.hpp>
+#include <algorithm>
+#include <map>
+#include <sstream>
+#include <unordered_map>
+
+namespace lvt {
+
+using json = nlohmann::json;
+
+struct IndexedElement {
+    const Element* element = nullptr;
+    std::string path;
+    std::string baseKey;
+    std::string key;
+};
+
+static std::string bounds_to_string(const Bounds& b) {
+    return std::to_string(b.x) + "," + std::to_string(b.y) + "," +
+           std::to_string(b.width) + "," + std::to_string(b.height);
+}
+
+static json bounds_to_json(const Bounds& b) {
+    return json{{"x", b.x}, {"y", b.y}, {"width", b.width}, {"height", b.height}};
+}
+
+static std::string escape_key_part(const std::string& value) {
+    std::string result;
+    result.reserve(value.size());
+    for (char c : value) {
+        if (c == '\\' || c == '|')
+            result += '\\';
+        result += c;
+    }
+    return result;
+}
+
+static std::string base_identity_key(const Element& el) {
+    return escape_key_part(el.framework) + "|" +
+           escape_key_part(el.type) + "|" +
+           escape_key_part(el.className);
+}
+
+static void collect_index(const Element& el, const std::string& path,
+                          std::vector<IndexedElement>& out,
+                          std::unordered_map<std::string, int>& counts) {
+    IndexedElement indexed;
+    indexed.element = &el;
+    indexed.path = path;
+    indexed.baseKey = base_identity_key(el);
+    out.push_back(indexed);
+    counts[indexed.baseKey]++;
+
+    for (size_t i = 0; i < el.children.size(); ++i) {
+        auto childPath = path.empty() ? std::to_string(i) : path + "." + std::to_string(i);
+        collect_index(el.children[i], childPath, out, counts);
+    }
+}
+
+static void assign_keys(std::vector<IndexedElement>& elements,
+                        const std::unordered_map<std::string, int>& counts) {
+    for (auto& indexed : elements) {
+        indexed.key = indexed.baseKey;
+        auto count = counts.find(indexed.baseKey);
+        if (count != counts.end() && count->second > 1)
+            indexed.key += "|@" + indexed.path;
+    }
+}
+
+static std::vector<IndexedElement> index_tree(const Element& root) {
+    std::vector<IndexedElement> elements;
+    std::unordered_map<std::string, int> counts;
+    collect_index(root, "0", elements, counts);
+    assign_keys(elements, counts);
+    return elements;
+}
+
+static void index_tree_pair(const Element& before, const Element& after,
+                            std::vector<IndexedElement>& beforeElements,
+                            std::vector<IndexedElement>& afterElements) {
+    std::unordered_map<std::string, int> beforeCounts;
+    std::unordered_map<std::string, int> afterCounts;
+    collect_index(before, "0", beforeElements, beforeCounts);
+    collect_index(after, "0", afterElements, afterCounts);
+
+    std::unordered_map<std::string, int> combinedCounts = beforeCounts;
+    for (const auto& [key, count] : afterCounts)
+        combinedCounts[key] = std::max(combinedCounts[key], count);
+
+    assign_keys(beforeElements, combinedCounts);
+    assign_keys(afterElements, combinedCounts);
+}
+
+static std::string property_string(const Element& el, const std::string& name) {
+    auto it = el.properties.find(name);
+    return it == el.properties.end() ? std::string() : it->second;
+}
+
+static void add_field_if_changed(std::map<std::string, FieldChange>& fields,
+                                 const std::string& name,
+                                 const std::string& before,
+                                 const std::string& after) {
+    if (before != after)
+        fields[name] = {before, after};
+}
+
+static std::map<std::string, FieldChange> diff_element_fields(const IndexedElement& before,
+                                                              const IndexedElement& after) {
+    std::map<std::string, FieldChange> fields;
+    add_field_if_changed(fields, "path", before.path, after.path);
+    add_field_if_changed(fields, "type", before.element->type, after.element->type);
+    add_field_if_changed(fields, "framework", before.element->framework, after.element->framework);
+    add_field_if_changed(fields, "className", before.element->className, after.element->className);
+    add_field_if_changed(fields, "text", before.element->text, after.element->text);
+    add_field_if_changed(fields, "bounds", bounds_to_string(before.element->bounds),
+                         bounds_to_string(after.element->bounds));
+
+    std::map<std::string, bool> propertyNames;
+    for (const auto& [name, value] : before.element->properties)
+        propertyNames[name] = true;
+    for (const auto& [name, value] : after.element->properties)
+        propertyNames[name] = true;
+    for (const auto& [name, ignored] : propertyNames) {
+        add_field_if_changed(fields, "properties." + name,
+                             property_string(*before.element, name),
+                             property_string(*after.element, name));
+    }
+
+    return fields;
+}
+
+static json element_to_json(const Element& el) {
+    json j;
+    j["id"] = el.id;
+    j["type"] = el.type;
+    j["framework"] = el.framework;
+    if (!el.className.empty()) j["className"] = el.className;
+    if (!el.text.empty()) j["text"] = el.text;
+    j["bounds"] = bounds_to_json(el.bounds);
+    if (!el.properties.empty())
+        j["properties"] = el.properties;
+    if (!el.children.empty()) {
+        j["children"] = json::array();
+        for (const auto& child : el.children)
+            j["children"].push_back(element_to_json(child));
+    }
+    return j;
+}
+
+static const char* event_type_name(ChangeEvent::Type type) {
+    switch (type) {
+    case ChangeEvent::Type::Added: return "added";
+    case ChangeEvent::Type::Removed: return "removed";
+    case ChangeEvent::Type::Changed: return "changed";
+    }
+    return "changed";
+}
+
+std::vector<ChangeEvent> snapshot_added_events(const Element& root) {
+    std::vector<ChangeEvent> events;
+    for (const auto& indexed : index_tree(root)) {
+        ChangeEvent event;
+        event.type = ChangeEvent::Type::Added;
+        event.key = indexed.key;
+        event.path = indexed.path;
+        event.element = *indexed.element;
+        events.push_back(std::move(event));
+    }
+    return events;
+}
+
+std::vector<ChangeEvent> diff_trees(const Element& before, const Element& after) {
+    std::vector<IndexedElement> beforeElements;
+    std::vector<IndexedElement> afterElements;
+    index_tree_pair(before, after, beforeElements, afterElements);
+
+    std::map<std::string, IndexedElement> beforeByKey;
+    std::map<std::string, IndexedElement> afterByKey;
+    for (const auto& indexed : beforeElements)
+        beforeByKey[indexed.key] = indexed;
+    for (const auto& indexed : afterElements)
+        afterByKey[indexed.key] = indexed;
+
+    std::vector<ChangeEvent> events;
+
+    for (const auto& [key, indexed] : afterByKey) {
+        if (beforeByKey.find(key) != beforeByKey.end())
+            continue;
+        ChangeEvent event;
+        event.type = ChangeEvent::Type::Added;
+        event.key = key;
+        event.path = indexed.path;
+        event.element = *indexed.element;
+        events.push_back(std::move(event));
+    }
+
+    for (const auto& [key, indexed] : beforeByKey) {
+        if (afterByKey.find(key) != afterByKey.end())
+            continue;
+        ChangeEvent event;
+        event.type = ChangeEvent::Type::Removed;
+        event.key = key;
+        event.path = indexed.path;
+        event.element = *indexed.element;
+        events.push_back(std::move(event));
+    }
+
+    for (const auto& [key, beforeIndexed] : beforeByKey) {
+        auto afterIt = afterByKey.find(key);
+        if (afterIt == afterByKey.end())
+            continue;
+        auto fields = diff_element_fields(beforeIndexed, afterIt->second);
+        if (fields.empty())
+            continue;
+        ChangeEvent event;
+        event.type = ChangeEvent::Type::Changed;
+        event.key = key;
+        event.path = afterIt->second.path;
+        event.element = *afterIt->second.element;
+        event.fields = std::move(fields);
+        events.push_back(std::move(event));
+    }
+
+    return events;
+}
+
+std::string serialize_change_event(const ChangeEvent& event) {
+    json j;
+    j["event"] = event_type_name(event.type);
+    j["key"] = event.key;
+    j["path"] = event.path;
+
+    if (event.type == ChangeEvent::Type::Changed) {
+        json fields = json::object();
+        for (const auto& [name, change] : event.fields) {
+            fields[name] = {{"old", change.oldValue}, {"new", change.newValue}};
+        }
+        j["fields"] = fields;
+    } else {
+        j["element"] = element_to_json(event.element);
+    }
+
+    return j.dump();
+}
+
+} // namespace lvt

--- a/src/watch_diff.h
+++ b/src/watch_diff.h
@@ -1,0 +1,32 @@
+#pragma once
+#include "element.h"
+#include <map>
+#include <string>
+#include <vector>
+
+namespace lvt {
+
+struct FieldChange {
+    std::string oldValue;
+    std::string newValue;
+};
+
+struct ChangeEvent {
+    enum class Type {
+        Added,
+        Removed,
+        Changed,
+    };
+
+    Type type = Type::Changed;
+    std::string key;
+    std::string path;
+    Element element;
+    std::map<std::string, FieldChange> fields;
+};
+
+std::vector<ChangeEvent> diff_trees(const Element& before, const Element& after);
+std::vector<ChangeEvent> snapshot_added_events(const Element& root);
+std::string serialize_change_event(const ChangeEvent& event);
+
+} // namespace lvt

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -4,6 +4,7 @@
 #include "element.h"
 #include "tree_builder.h"
 #include "json_serializer.h"
+#include "watch_diff.h"
 #include "framework_detector.h"
 #include "target.h"
 #include <nlohmann/json.hpp>
@@ -362,6 +363,97 @@ TEST(Element, TreeConstruction) {
     EXPECT_EQ(root.children.size(), 2);
     EXPECT_EQ(root.children[0].type, "Child1");
     EXPECT_EQ(root.children[1].type, "Child2");
+}
+
+// ---- Watch diff ----
+
+static Element diff_el(const std::string& type, const std::string& className,
+                       const std::string& text = "") {
+    Element el;
+    el.type = type;
+    el.framework = "win32";
+    el.className = className;
+    el.text = text;
+    return el;
+}
+
+TEST(WatchDiff, AddedElement) {
+    auto before = diff_el("Window", "Root");
+    auto after = before;
+    after.children.push_back(diff_el("Button", "Button", "OK"));
+
+    auto events = diff_trees(before, after);
+
+    ASSERT_EQ(events.size(), 1);
+    EXPECT_EQ(events[0].type, ChangeEvent::Type::Added);
+    EXPECT_EQ(events[0].path, "0.0");
+    EXPECT_EQ(events[0].element.text, "OK");
+}
+
+TEST(WatchDiff, RemovedElement) {
+    auto before = diff_el("Window", "Root");
+    before.children.push_back(diff_el("Button", "Button", "OK"));
+    auto after = diff_el("Window", "Root");
+
+    auto events = diff_trees(before, after);
+
+    ASSERT_EQ(events.size(), 1);
+    EXPECT_EQ(events[0].type, ChangeEvent::Type::Removed);
+    EXPECT_EQ(events[0].path, "0.0");
+    EXPECT_EQ(events[0].element.text, "OK");
+}
+
+TEST(WatchDiff, ChangedElementFields) {
+    auto before = diff_el("Window", "Root");
+    before.children.push_back(diff_el("Button", "Button", "OK"));
+    before.children[0].bounds = {1, 2, 3, 4};
+    before.children[0].properties["enabled"] = "true";
+
+    auto after = before;
+    after.children[0].text = "Cancel";
+    after.children[0].bounds = {5, 6, 7, 8};
+    after.children[0].properties["enabled"] = "false";
+
+    auto events = diff_trees(before, after);
+
+    ASSERT_EQ(events.size(), 1);
+    EXPECT_EQ(events[0].type, ChangeEvent::Type::Changed);
+    EXPECT_EQ(events[0].fields["text"].oldValue, "OK");
+    EXPECT_EQ(events[0].fields["text"].newValue, "Cancel");
+    EXPECT_EQ(events[0].fields["bounds"].oldValue, "1,2,3,4");
+    EXPECT_EQ(events[0].fields["bounds"].newValue, "5,6,7,8");
+    EXPECT_EQ(events[0].fields["properties.enabled"].oldValue, "true");
+    EXPECT_EQ(events[0].fields["properties.enabled"].newValue, "false");
+}
+
+TEST(WatchDiff, MovedElement) {
+    auto before = diff_el("Window", "Root");
+    before.children.push_back(diff_el("Pane", "Pane"));
+    before.children.push_back(diff_el("Button", "Button", "OK"));
+
+    auto after = diff_el("Window", "Root");
+    after.children.push_back(diff_el("Pane", "Pane"));
+    after.children[0].children.push_back(diff_el("Button", "Button", "OK"));
+
+    auto events = diff_trees(before, after);
+
+    ASSERT_EQ(events.size(), 1);
+    EXPECT_EQ(events[0].type, ChangeEvent::Type::Changed);
+    EXPECT_EQ(events[0].fields["path"].oldValue, "0.1");
+    EXPECT_EQ(events[0].fields["path"].newValue, "0.0.0");
+}
+
+TEST(WatchDiff, SerializeChangedEvent) {
+    ChangeEvent event;
+    event.type = ChangeEvent::Type::Changed;
+    event.key = "win32|Button|Button";
+    event.path = "0.0";
+    event.fields["text"] = {"OK", "Cancel"};
+
+    auto j = json::parse(serialize_change_event(event));
+    EXPECT_EQ(j["event"], "changed");
+    EXPECT_EQ(j["fields"]["text"]["old"], "OK");
+    EXPECT_EQ(j["fields"]["text"]["new"], "Cancel");
 }
 
 // ---- Large tree serialization ----


### PR DESCRIPTION
Adds --watch/--interval support with newline-delimited JSON tree diff events, a pure unit-tested diff engine for added/removed/changed/moved elements, and README docs. Fixes #16