### PR TITLE
Durable element identity (stable keys) + --query

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(lvt
     src/target.cpp
     src/framework_detector.cpp
     src/tree_builder.cpp
+    src/element_key.cpp
     src/json_serializer.cpp
     src/watch_diff.cpp
     src/screenshot.cpp
@@ -264,6 +265,7 @@ find_package(GTest CONFIG REQUIRED)
 add_executable(lvt_unit_tests
     tests/unit_tests.cpp
     src/tree_builder.cpp
+    src/element_key.cpp
     src/json_serializer.cpp
     src/watch_diff.cpp
     src/framework_detector.cpp

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ lvt --hwnd 0x1A0B3C --frameworks
 # Scope to a subtree
 lvt --name myapp --element e5 --depth 3
 
+# Query an element by durable key or eN id
+lvt --name myapp --query "win32|Window|MyWindow/win32|Button|Button|Name:OK" text
+
 # Screenshot + tree dump together
 lvt --name notepad --screenshot out.png --dump
 
@@ -94,7 +97,8 @@ lvt --name notepad --watch --interval 250
 | `--dump` | Output the tree (default unless `--screenshot` is used) |
 | `--watch` | Emit live JSON tree diff events until Ctrl+C |
 | `--interval <ms>` | Polling interval for `--watch` (default: 500) |
-| `--element <id>` | Scope to a specific element subtree |
+| `--element <ref>` | Scope to a specific element subtree by positional `eN` id or durable key |
+| `--query <ref> [prop]` | Output an element, or one property, by positional `eN` id or durable key |
 | `--frameworks` | Just list detected frameworks |
 | `--depth <n>` | Max tree traversal depth |
 

--- a/src/element.h
+++ b/src/element.h
@@ -15,6 +15,7 @@ struct Bounds {
 
 struct Element {
     std::string id;
+    std::string key;
     std::string type;
     std::string framework;
     std::string className;

--- a/src/element_key.cpp
+++ b/src/element_key.cpp
@@ -1,0 +1,147 @@
+#include "element_key.h"
+#include <algorithm>
+#include <iomanip>
+#include <map>
+#include <sstream>
+
+namespace lvt {
+
+std::string escape_key_part(const std::string& value) {
+    std::string result;
+    result.reserve(value.size());
+    for (char c : value) {
+        if (c == '\\' || c == '|' || c == '/' || c == ':')
+            result += '\\';
+        result += c;
+    }
+    return result;
+}
+
+std::string base_identity_key(const Element& el) {
+    return escape_key_part(el.framework) + "|" +
+           escape_key_part(el.type) + "|" +
+           escape_key_part(el.className);
+}
+
+void collect_index(const Element& el, const std::string& path,
+                   std::vector<IndexedElement>& out,
+                   std::unordered_map<std::string, int>& counts) {
+    IndexedElement indexed;
+    indexed.element = &el;
+    indexed.path = path;
+    indexed.baseKey = base_identity_key(el);
+    out.push_back(indexed);
+    counts[indexed.baseKey]++;
+
+    for (size_t i = 0; i < el.children.size(); ++i) {
+        auto childPath = path.empty() ? std::to_string(i) : path + "." + std::to_string(i);
+        collect_index(el.children[i], childPath, out, counts);
+    }
+}
+
+void assign_keys(std::vector<IndexedElement>& elements,
+                 const std::unordered_map<std::string, int>& counts) {
+    for (auto& indexed : elements) {
+        indexed.key = indexed.baseKey;
+        auto count = counts.find(indexed.baseKey);
+        if (count != counts.end() && count->second > 1)
+            indexed.key += "|@" + indexed.path;
+    }
+}
+
+std::vector<IndexedElement> index_tree(const Element& root) {
+    std::vector<IndexedElement> elements;
+    std::unordered_map<std::string, int> counts;
+    collect_index(root, "0", elements, counts);
+    assign_keys(elements, counts);
+    return elements;
+}
+
+void index_tree_pair(const Element& before, const Element& after,
+                     std::vector<IndexedElement>& beforeElements,
+                     std::vector<IndexedElement>& afterElements) {
+    std::unordered_map<std::string, int> beforeCounts;
+    std::unordered_map<std::string, int> afterCounts;
+    collect_index(before, "0", beforeElements, beforeCounts);
+    collect_index(after, "0", afterElements, afterCounts);
+
+    std::unordered_map<std::string, int> combinedCounts = beforeCounts;
+    for (const auto& [key, count] : afterCounts)
+        combinedCounts[key] = std::max(combinedCounts[key], count);
+
+    assign_keys(beforeElements, combinedCounts);
+    assign_keys(afterElements, combinedCounts);
+}
+
+static std::string hwnd_key(uintptr_t handle) {
+    std::ostringstream out;
+    out << "hwnd:0x" << std::hex << std::uppercase << handle;
+    return out.str();
+}
+
+static std::string stable_name_key(const Element& el) {
+    for (const char* name : {"AutomationId", "x:Name", "Name", "automationId", "name"}) {
+        auto it = el.properties.find(name);
+        if (it != el.properties.end() && !it->second.empty())
+            return std::string(name) + ":" + escape_key_part(it->second);
+    }
+    return {};
+}
+
+static std::string discriminator_for_child(const Element& child, size_t childIndex,
+                                           const std::map<std::string, int>& baseCounts,
+                                           const std::map<std::string, int>& hwndCounts,
+                                           const std::map<std::string, int>& nameCounts) {
+    auto base = base_identity_key(child);
+    if (child.nativeHandle != 0) {
+        auto hwnd = hwnd_key(child.nativeHandle);
+        auto full = base + "|" + hwnd;
+        auto count = hwndCounts.find(full);
+        if (count == hwndCounts.end() || count->second == 1)
+            return full;
+    }
+
+    auto name = stable_name_key(child);
+    if (!name.empty()) {
+        auto full = base + "|" + name;
+        auto count = nameCounts.find(full);
+        if (count == nameCounts.end() || count->second == 1)
+            return full;
+    }
+
+    auto baseIt = baseCounts.find(base);
+    if (baseIt == baseCounts.end() || baseIt->second <= 1)
+        return base;
+
+    return base + "|@" + std::to_string(childIndex);
+}
+
+static void assign_child_keys(Element& parent, const std::string& parentKey) {
+    std::map<std::string, int> baseCounts;
+    std::map<std::string, int> hwndCounts;
+    std::map<std::string, int> nameCounts;
+
+    for (const auto& child : parent.children) {
+        auto base = base_identity_key(child);
+        baseCounts[base]++;
+        if (child.nativeHandle != 0)
+            hwndCounts[base + "|" + hwnd_key(child.nativeHandle)]++;
+        auto name = stable_name_key(child);
+        if (!name.empty())
+            nameCounts[base + "|" + name]++;
+    }
+
+    for (size_t i = 0; i < parent.children.size(); ++i) {
+        auto& child = parent.children[i];
+        auto segment = discriminator_for_child(child, i, baseCounts, hwndCounts, nameCounts);
+        child.key = parentKey.empty() ? segment : parentKey + "/" + segment;
+        assign_child_keys(child, child.key);
+    }
+}
+
+void assign_element_keys(Element& root) {
+    root.key = base_identity_key(root);
+    assign_child_keys(root, root.key);
+}
+
+} // namespace lvt

--- a/src/element_key.h
+++ b/src/element_key.h
@@ -1,0 +1,31 @@
+#pragma once
+#include "element.h"
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace lvt {
+
+struct IndexedElement {
+    const Element* element = nullptr;
+    std::string path;
+    std::string baseKey;
+    std::string key;
+};
+
+std::string escape_key_part(const std::string& value);
+std::string base_identity_key(const Element& el);
+
+void collect_index(const Element& el, const std::string& path,
+                   std::vector<IndexedElement>& out,
+                   std::unordered_map<std::string, int>& counts);
+void assign_keys(std::vector<IndexedElement>& elements,
+                 const std::unordered_map<std::string, int>& counts);
+std::vector<IndexedElement> index_tree(const Element& root);
+void index_tree_pair(const Element& before, const Element& after,
+                     std::vector<IndexedElement>& beforeElements,
+                     std::vector<IndexedElement>& afterElements);
+
+void assign_element_keys(Element& root);
+
+} // namespace lvt

--- a/src/json_serializer.cpp
+++ b/src/json_serializer.cpp
@@ -24,6 +24,7 @@ static json element_to_json(const Element& el) {
         return r;
     };
     j["id"] = el.id;
+    j["key"] = el.key;
     j["type"] = sanitize(el.type);
     j["framework"] = el.framework;
     if (!el.className.empty()) j["className"] = sanitize(el.className);
@@ -109,6 +110,7 @@ static void element_to_xml(const Element& el, std::ostringstream& out, int inden
 
     out << pad << "<" << tag;
     out << " id=\"" << xml_escape(el.id) << "\"";
+    out << " key=\"" << xml_escape(el.key) << "\"";
     out << " framework=\"" << xml_escape(el.framework) << "\"";
     if (!el.className.empty() && el.className != el.type)
         out << " className=\"" << xml_escape(el.className) << "\"";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <string>
 #include <fstream>
+#include <sstream>
 #include <nlohmann/json.hpp>
 #include <atomic>
 #include <chrono>
@@ -54,7 +55,8 @@ static void print_usage() {
         "  --dump               Output the tree (default; implied unless --screenshot)\n"
         "  --watch              Emit live JSON tree diff events until Ctrl+C\n"
         "  --interval <ms>      Watch polling interval (default: 500)\n"
-        "  --element <id>       Scope to a specific element subtree\n"
+        "  --element <ref>      Scope to a specific element subtree by id or key\n"
+        "  --query <ref> [prop] Output one element or one property by id or key\n"
         "  --frameworks         Just detect and list frameworks\n"
         "  --depth <n>          Max tree traversal depth (default: unlimited)\n"
         "  --debug              Show verbose diagnostic output\n"
@@ -74,6 +76,8 @@ struct Args {
     std::string annotationsFile;
 #endif
     std::string elementId;
+    std::string queryId;
+    std::string queryProperty;
     int depth = -1;
     int intervalMs = 500;
     bool frameworksOnly = false;
@@ -109,6 +113,14 @@ static Args parse_args(int argc, char* argv[]) {
 #endif
         } else if (strcmp(argv[i], "--element") == 0 && i + 1 < argc) {
             args.elementId = argv[++i];
+        } else if (strcmp(argv[i], "--query") == 0) {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "lvt: --query requires an element id or key\n");
+                exit(1);
+            }
+            args.queryId = argv[++i];
+            if (i + 1 < argc && strncmp(argv[i + 1], "--", 2) != 0)
+                args.queryProperty = argv[++i];
         } else if (strcmp(argv[i], "--depth") == 0 && i + 1 < argc) {
             args.depth = atoi(argv[++i]);
         } else if (strcmp(argv[i], "--watch") == 0) {
@@ -131,15 +143,6 @@ static Args parse_args(int argc, char* argv[]) {
     return args;
 }
 
-static lvt::Element* find_element(lvt::Element& root, const std::string& id) {
-    if (root.id == id) return &root;
-    for (auto& child : root.children) {
-        auto* found = find_element(child, id);
-        if (found) return found;
-    }
-    return nullptr;
-}
-
 static std::vector<std::string> framework_names(const std::vector<lvt::FrameworkInfo>& frameworks) {
     std::vector<std::string> names;
     for (auto& fi : frameworks) {
@@ -152,6 +155,70 @@ static std::vector<std::string> framework_names(const std::vector<lvt::Framework
     return names;
 }
 
+static std::string xml_escape(const std::string& s) {
+    std::string r;
+    r.reserve(s.size());
+    for (char c : s) {
+        switch (c) {
+        case '&':  r += "&amp;";  break;
+        case '<':  r += "&lt;";   break;
+        case '>':  r += "&gt;";   break;
+        case '"':  r += "&quot;"; break;
+        case '\'': r += "&apos;"; break;
+        default:
+            if (static_cast<unsigned char>(c) >= 0x20)
+                r += c;
+        }
+    }
+    return r;
+}
+
+static nlohmann::json query_element_to_json(const lvt::Element& element) {
+    nlohmann::json j;
+    j["id"] = element.id;
+    j["key"] = element.key;
+    j["type"] = element.type;
+    j["framework"] = element.framework;
+    j["className"] = element.className;
+    j["text"] = element.text;
+    j["bounds"] = lvt::get_element_property(element, "bounds").value();
+    for (auto& [key, value] : element.properties)
+        j[key] = value;
+    return j;
+}
+
+static std::string query_element_to_xml(const lvt::Element& element) {
+    std::ostringstream out;
+    out << "<Element";
+    out << " id=\"" << xml_escape(element.id) << "\"";
+    out << " key=\"" << xml_escape(element.key) << "\"";
+    out << " type=\"" << xml_escape(element.type) << "\"";
+    out << " framework=\"" << xml_escape(element.framework) << "\"";
+    out << " className=\"" << xml_escape(element.className) << "\"";
+    out << " text=\"" << xml_escape(element.text) << "\"";
+    out << " bounds=\"" << xml_escape(lvt::get_element_property(element, "bounds").value()) << "\"";
+    for (auto& [key, value] : element.properties)
+        out << " " << xml_escape(key) << "=\"" << xml_escape(value) << "\"";
+    out << " />";
+    return out.str();
+}
+
+static bool write_output(const std::string& outputFile, const std::string& content) {
+    if (outputFile.empty()) {
+        printf("%s\n", content.c_str());
+        return true;
+    }
+    std::ofstream out(outputFile);
+    if (!out) {
+        fprintf(stderr, "lvt: cannot write to '%s'\n", outputFile.c_str());
+        return false;
+    }
+    out << content << "\n";
+    if (lvt::g_debug)
+        fprintf(stderr, "lvt: wrote output to %s\n", outputFile.c_str());
+    return true;
+}
+
 static bool build_output_tree(const lvt::TargetInfo& target, const Args& args,
                               lvt::Element& outputTree) {
     auto frameworks = lvt::detect_frameworks(target.hwnd, target.pid);
@@ -159,7 +226,7 @@ static bool build_output_tree(const lvt::TargetInfo& target, const Args& args,
 
     lvt::Element* outputRoot = &tree;
     if (!args.elementId.empty()) {
-        outputRoot = find_element(tree, args.elementId);
+        outputRoot = lvt::find_element_by_ref(tree, args.elementId);
         if (!outputRoot) {
             fprintf(stderr, "lvt: element '%s' not found\n", args.elementId.c_str());
             return false;
@@ -233,6 +300,10 @@ int main(int argc, char* argv[]) {
     }
     if (args.watch && args.format != "json") {
         fprintf(stderr, "lvt: --watch emits JSON events; --format must be json\n");
+        return 1;
+    }
+    if (args.format != "json" && args.format != "xml") {
+        fprintf(stderr, "lvt: --format must be json or xml\n");
         return 1;
     }
 
@@ -333,11 +404,39 @@ int main(int argc, char* argv[]) {
     // Scope to element if requested
     lvt::Element* outputRoot = &tree;
     if (!args.elementId.empty()) {
-        outputRoot = find_element(tree, args.elementId);
+        outputRoot = lvt::find_element_by_ref(tree, args.elementId);
         if (!outputRoot) {
             fprintf(stderr, "lvt: element '%s' not found\n", args.elementId.c_str());
             return 1;
         }
+    }
+
+    if (!args.queryId.empty()) {
+        auto* queryElement = lvt::find_element_by_ref(tree, args.queryId);
+        if (!queryElement) {
+            fprintf(stderr, "lvt: element '%s' not found\n", args.queryId.c_str());
+            return 1;
+        }
+
+        std::string queryOutput;
+        if (!args.queryProperty.empty()) {
+            auto value = lvt::get_element_property(*queryElement, args.queryProperty);
+            if (!value) {
+                fprintf(stderr, "lvt: property '%s' not found on element '%s'\n",
+                        args.queryProperty.c_str(), args.queryId.c_str());
+                return 1;
+            }
+            queryOutput = *value;
+        } else if (args.format == "xml") {
+            queryOutput = query_element_to_xml(*queryElement);
+        } else {
+            queryOutput = query_element_to_json(*queryElement).dump(2);
+        }
+
+        if (!write_output(args.outputFile, queryOutput))
+            return 1;
+        lvt::unload_plugins();
+        return 0;
     }
 
     // Apply depth limit relative to the output root
@@ -357,18 +456,8 @@ int main(int argc, char* argv[]) {
                                                  target.processName, frameworkNames);
         }
 
-        if (args.outputFile.empty()) {
-            printf("%s\n", serialized.c_str());
-        } else {
-            std::ofstream out(args.outputFile);
-            if (!out) {
-                fprintf(stderr, "lvt: cannot write to '%s'\n", args.outputFile.c_str());
-                return 1;
-            }
-            out << serialized << "\n";
-            if (lvt::g_debug)
-                fprintf(stderr, "lvt: wrote tree to %s\n", args.outputFile.c_str());
-        }
+        if (!write_output(args.outputFile, serialized))
+            return 1;
     }
 
     // Screenshot

--- a/src/plugin_loader.cpp
+++ b/src/plugin_loader.cpp
@@ -135,8 +135,11 @@ static void graft_json_node(const json& j, Element& parent, const std::string& f
     el.framework = framework;
     el.className = sanitize(j.value("type", ""));
     el.text = sanitize(j.value("text", ""));
+    auto name = sanitize(j.value("name", ""));
+    if (!name.empty())
+        el.properties["name"] = name;
     if (el.text.empty())
-        el.text = sanitize(j.value("name", ""));
+        el.text = name;
 
     auto lastDot = el.className.rfind('.');
     el.type = (lastDot != std::string::npos) ? el.className.substr(lastDot + 1) : el.className;

--- a/src/providers/wpf_inject.cpp
+++ b/src/providers/wpf_inject.cpp
@@ -64,9 +64,13 @@ static void graft_json_node(const json& j, Element& parent, const std::string& f
     auto lastDot = el.className.rfind('.');
     el.type = (lastDot != std::string::npos) ? el.className.substr(lastDot + 1) : el.className;
 
+    auto name = sanitize(j.value("name", ""));
+    if (!name.empty())
+        el.properties["name"] = name;
+
     el.text = sanitize(j.value("text", ""));
     if (el.text.empty())
-        el.text = sanitize(j.value("name", ""));
+        el.text = name;
 
     double w = j.value("width", 0.0);
     double h = j.value("height", 0.0);

--- a/src/providers/xaml_diag_common.cpp
+++ b/src/providers/xaml_diag_common.cpp
@@ -16,6 +16,7 @@
 #include <xamlOM.h>
 #include <nlohmann/json.hpp>
 #include <cstdio>
+#include <set>
 #include <string>
 
 #pragma comment(lib, "userenv.lib")
@@ -133,11 +134,19 @@ static void collect_bridges(Element& el, std::vector<Element*>& bridges) {
     }
 }
 
+static std::string bridge_identity(const Element& el) {
+    if (el.nativeHandle != 0)
+        return std::to_string(el.nativeHandle);
+    auto it = el.properties.find("hwnd");
+    return it == el.properties.end() ? std::string() : it->second;
+}
+
 // Recursively graft JSON tree nodes into an Element tree.
 // parentOffsetX/Y accumulate offsets from the XAML root for screen coordinate computation.
 static void graft_json_node(const json& j, Element& parent, const std::string& framework,
                             double parentOffsetX = 0, double parentOffsetY = 0) {
-    Element el;
+    parent.children.emplace_back();
+    Element& el = parent.children.back();
     el.framework = framework;
     el.className = sanitize(j.value("type", ""));
 
@@ -205,7 +214,6 @@ static void graft_json_node(const json& j, Element& parent, const std::string& f
         }
     }
 
-    parent.children.push_back(std::move(el));
 }
 
 bool inject_and_collect_xaml_tree(
@@ -393,9 +401,7 @@ bool inject_and_collect_xaml_tree(
     // This is more robust than order-based matching since Win32 HWND enumeration order
     // may differ from XAML tree root enumeration order.
     if (treeJson.is_array()) {
-        std::vector<Element*> bridges;
-        collect_bridges(root, bridges);
-        std::vector<bool> bridgeUsed(bridges.size(), false);
+        std::set<std::string> usedBridges;
 
         for (auto& node : treeJson) {
             std::string typeName = sanitize(node.value("type", ""));
@@ -436,10 +442,13 @@ bool inject_and_collect_xaml_tree(
             }
 
             // Find the best-matching bridge by size similarity
+            std::vector<Element*> bridges;
+            collect_bridges(root, bridges);
             int bestIdx = -1;
             double bestScore = 1e18;
             for (size_t i = 0; i < bridges.size(); i++) {
-                if (bridgeUsed[i]) continue;
+                auto identity = bridge_identity(*bridges[i]);
+                if (!identity.empty() && usedBridges.count(identity)) continue;
                 double bw = bridges[i]->bounds.width;
                 double bh = bridges[i]->bounds.height;
                 // Score: prefer bridges whose dimensions best accommodate the content
@@ -453,8 +462,10 @@ bool inject_and_collect_xaml_tree(
             }
 
             if (bestIdx >= 0) {
-                bridgeUsed[bestIdx] = true;
                 auto* bridge = bridges[bestIdx];
+                auto identity = bridge_identity(*bridge);
+                if (!identity.empty())
+                    usedBridges.insert(identity);
                 double baseX = bridge->bounds.x;
                 double baseY = bridge->bounds.y;
                 graft_json_node(node, *bridge, frameworkLabel, baseX, baseY);

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -1,4 +1,5 @@
 #include "screenshot.h"
+#include "tree_builder.h"
 #include <wil/com.h>
 #include <wil/resource.h>
 
@@ -28,15 +29,6 @@ IDirect3DDxgiInterfaceAccess : public IUnknown {
 };
 
 namespace lvt {
-
-static const Element* find_element_by_id(const Element& root, const std::string& id) {
-    if (root.id == id) return &root;
-    for (auto& child : root.children) {
-        auto* found = find_element_by_id(child, id);
-        if (found) return found;
-    }
-    return nullptr;
-}
 
 static void collect_elements(const Element& el, std::vector<const Element*>& out) {
     out.push_back(&el);
@@ -413,7 +405,7 @@ bool capture_screenshot(HWND hwnd, const std::string& outputPath,
     RECT cropRect{};
     const RECT* cropPtr = nullptr;
     if (!elementId.empty() && tree) {
-        auto* el = find_element_by_id(*tree, elementId);
+        auto* el = find_element_by_ref(*tree, elementId);
         if (el && el->bounds.width > 0 && el->bounds.height > 0) {
             RECT winRect{};
             if (DwmGetWindowAttribute(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS,

--- a/src/tree_builder.cpp
+++ b/src/tree_builder.cpp
@@ -1,4 +1,5 @@
 #include "tree_builder.h"
+#include "element_key.h"
 #include "providers/provider.h"
 #include "providers/win32_provider.h"
 #include "providers/comctl_provider.h"
@@ -8,6 +9,8 @@
 #include "plugin_loader.h"
 #include <algorithm>
 #include <memory>
+#include <optional>
+#include <sstream>
 
 namespace lvt {
 
@@ -31,6 +34,73 @@ static void trim_to_depth_impl(Element& el, int currentDepth, int maxDepth) {
 void assign_element_ids(Element& root) {
     int counter = 0;
     assign_ids_recursive(root, counter);
+}
+
+Element* find_element_by_id(Element& root, const std::string& id) {
+    if (root.id == id) return &root;
+    for (auto& child : root.children) {
+        auto* found = find_element_by_id(child, id);
+        if (found) return found;
+    }
+    return nullptr;
+}
+
+const Element* find_element_by_id(const Element& root, const std::string& id) {
+    if (root.id == id) return &root;
+    for (auto& child : root.children) {
+        auto* found = find_element_by_id(child, id);
+        if (found) return found;
+    }
+    return nullptr;
+}
+
+Element* find_element_by_key(Element& root, const std::string& key) {
+    if (root.key == key) return &root;
+    for (auto& child : root.children) {
+        auto* found = find_element_by_key(child, key);
+        if (found) return found;
+    }
+    return nullptr;
+}
+
+const Element* find_element_by_key(const Element& root, const std::string& key) {
+    if (root.key == key) return &root;
+    for (auto& child : root.children) {
+        auto* found = find_element_by_key(child, key);
+        if (found) return found;
+    }
+    return nullptr;
+}
+
+Element* find_element_by_ref(Element& root, const std::string& ref) {
+    if (auto* byId = find_element_by_id(root, ref))
+        return byId;
+    return find_element_by_key(root, ref);
+}
+
+const Element* find_element_by_ref(const Element& root, const std::string& ref) {
+    if (auto* byId = find_element_by_id(root, ref))
+        return byId;
+    return find_element_by_key(root, ref);
+}
+
+std::optional<std::string> get_element_property(const Element& element, const std::string& property) {
+    if (property == "id") return element.id;
+    if (property == "key") return element.key;
+    if (property == "type") return element.type;
+    if (property == "framework") return element.framework;
+    if (property == "className") return element.className;
+    if (property == "text") return element.text;
+    if (property == "bounds") {
+        std::ostringstream out;
+        out << element.bounds.x << "," << element.bounds.y << ","
+            << element.bounds.width << "," << element.bounds.height;
+        return out.str();
+    }
+
+    auto it = element.properties.find(property);
+    if (it != element.properties.end()) return it->second;
+    return std::nullopt;
 }
 
 void trim_to_depth(Element& root, int maxDepth) {
@@ -86,6 +156,7 @@ Element build_tree(HWND hwnd, DWORD pid, const std::vector<FrameworkInfo>& frame
 
     // Assign IDs on the full tree so that element IDs are stable regardless of --depth.
     assign_element_ids(root);
+    assign_element_keys(root);
 
     return root;
 }

--- a/src/tree_builder.h
+++ b/src/tree_builder.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "element.h"
 #include "framework_detector.h"
+#include <optional>
+#include <string>
 #include <vector>
 
 namespace lvt {
@@ -10,6 +12,17 @@ Element build_tree(HWND hwnd, DWORD pid, const std::vector<FrameworkInfo>& frame
 
 // Assign deterministic element IDs (e0, e1, ...) in depth-first order.
 void assign_element_ids(Element& root);
+
+// Find an element by its assigned positional ID, durable key, or either (ID first).
+Element* find_element_by_id(Element& root, const std::string& id);
+const Element* find_element_by_id(const Element& root, const std::string& id);
+Element* find_element_by_key(Element& root, const std::string& key);
+const Element* find_element_by_key(const Element& root, const std::string& key);
+Element* find_element_by_ref(Element& root, const std::string& ref);
+const Element* find_element_by_ref(const Element& root, const std::string& ref);
+
+// Return a built-in or dynamic element property value.
+std::optional<std::string> get_element_property(const Element& element, const std::string& property);
 
 // Trim element tree to a maximum depth (0 = root only, 1 = root + children, etc.)
 void trim_to_depth(Element& root, int maxDepth);

--- a/src/watch_diff.cpp
+++ b/src/watch_diff.cpp
@@ -1,20 +1,12 @@
 #include "watch_diff.h"
+#include "element_key.h"
 #include <nlohmann/json.hpp>
-#include <algorithm>
 #include <map>
 #include <sstream>
-#include <unordered_map>
 
 namespace lvt {
 
 using json = nlohmann::json;
-
-struct IndexedElement {
-    const Element* element = nullptr;
-    std::string path;
-    std::string baseKey;
-    std::string key;
-};
 
 static std::string bounds_to_string(const Bounds& b) {
     return std::to_string(b.x) + "," + std::to_string(b.y) + "," +
@@ -23,73 +15,6 @@ static std::string bounds_to_string(const Bounds& b) {
 
 static json bounds_to_json(const Bounds& b) {
     return json{{"x", b.x}, {"y", b.y}, {"width", b.width}, {"height", b.height}};
-}
-
-static std::string escape_key_part(const std::string& value) {
-    std::string result;
-    result.reserve(value.size());
-    for (char c : value) {
-        if (c == '\\' || c == '|')
-            result += '\\';
-        result += c;
-    }
-    return result;
-}
-
-static std::string base_identity_key(const Element& el) {
-    return escape_key_part(el.framework) + "|" +
-           escape_key_part(el.type) + "|" +
-           escape_key_part(el.className);
-}
-
-static void collect_index(const Element& el, const std::string& path,
-                          std::vector<IndexedElement>& out,
-                          std::unordered_map<std::string, int>& counts) {
-    IndexedElement indexed;
-    indexed.element = &el;
-    indexed.path = path;
-    indexed.baseKey = base_identity_key(el);
-    out.push_back(indexed);
-    counts[indexed.baseKey]++;
-
-    for (size_t i = 0; i < el.children.size(); ++i) {
-        auto childPath = path.empty() ? std::to_string(i) : path + "." + std::to_string(i);
-        collect_index(el.children[i], childPath, out, counts);
-    }
-}
-
-static void assign_keys(std::vector<IndexedElement>& elements,
-                        const std::unordered_map<std::string, int>& counts) {
-    for (auto& indexed : elements) {
-        indexed.key = indexed.baseKey;
-        auto count = counts.find(indexed.baseKey);
-        if (count != counts.end() && count->second > 1)
-            indexed.key += "|@" + indexed.path;
-    }
-}
-
-static std::vector<IndexedElement> index_tree(const Element& root) {
-    std::vector<IndexedElement> elements;
-    std::unordered_map<std::string, int> counts;
-    collect_index(root, "0", elements, counts);
-    assign_keys(elements, counts);
-    return elements;
-}
-
-static void index_tree_pair(const Element& before, const Element& after,
-                            std::vector<IndexedElement>& beforeElements,
-                            std::vector<IndexedElement>& afterElements) {
-    std::unordered_map<std::string, int> beforeCounts;
-    std::unordered_map<std::string, int> afterCounts;
-    collect_index(before, "0", beforeElements, beforeCounts);
-    collect_index(after, "0", afterElements, afterCounts);
-
-    std::unordered_map<std::string, int> combinedCounts = beforeCounts;
-    for (const auto& [key, count] : afterCounts)
-        combinedCounts[key] = std::max(combinedCounts[key], count);
-
-    assign_keys(beforeElements, combinedCounts);
-    assign_keys(afterElements, combinedCounts);
 }
 
 static std::string property_string(const Element& el, const std::string& name) {
@@ -133,6 +58,7 @@ static std::map<std::string, FieldChange> diff_element_fields(const IndexedEleme
 static json element_to_json(const Element& el) {
     json j;
     j["id"] = el.id;
+    j["key"] = el.key;
     j["type"] = el.type;
     j["framework"] = el.framework;
     if (!el.className.empty()) j["className"] = el.className;

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -49,6 +49,17 @@ static std::string make_cmd(const std::string& lvt, const std::string& args) {
     return "\"" + lvt + "\" " + args;
 }
 
+static std::string cmd_escape_arg(std::string arg) {
+    std::string escaped;
+    escaped.reserve(arg.size());
+    for (char c : arg) {
+        if (c == '|' || c == '&' || c == '<' || c == '>' || c == '^')
+            escaped += '^';
+        escaped += c;
+    }
+    return escaped;
+}
+
 // Launch a dedicated Notepad instance for testing
 class NotepadFixture : public ::testing::Test {
 protected:
@@ -310,6 +321,23 @@ static void collect_json_elements(const json& el, std::vector<const json*>& out)
     }
 }
 
+static void collect_stable_win32_map(const json& el, const std::string& path,
+                                     std::map<std::string, std::string>& out) {
+    if (el.value("framework", "") == "win32") {
+        auto key = el.value("key", "");
+        if (!key.empty()) {
+            out[key] = el.value("framework", "") + "|" +
+                       el.value("type", "") + "|" +
+                       el.value("className", "") + "|" + path;
+        }
+    }
+
+    if (el.contains("children") && el["children"].is_array()) {
+        for (size_t i = 0; i < el["children"].size(); ++i) {
+            collect_stable_win32_map(el["children"][i], path + "." + std::to_string(i), out);
+        }
+    }
+}
 TEST_F(NotepadFixture, Win32BoundsReasonable) {
     // Every element in the Win32 tree should have reasonable (non-extreme) bounds
     auto lvt = get_lvt_path();
@@ -352,6 +380,45 @@ TEST_F(NotepadFixture, RootBoundsNonZero) {
     auto& b = j["root"]["bounds"];
     EXPECT_GT(b["width"].get<int>(), 0) << "Root width should be positive";
     EXPECT_GT(b["height"].get<int>(), 0) << "Root height should be positive";
+}
+
+TEST_F(NotepadFixture, DurableKeysDeterministicAcrossTwoRuns) {
+    auto lvt = get_lvt_path();
+    auto first = run_command(make_cmd(lvt, get_pid_arg()));
+    auto second = run_command(make_cmd(lvt, get_pid_arg()));
+    ASSERT_FALSE(first.empty());
+    ASSERT_FALSE(second.empty());
+
+    auto j1 = json::parse(first, nullptr, false);
+    auto j2 = json::parse(second, nullptr, false);
+    ASSERT_FALSE(j1.is_discarded());
+    ASSERT_FALSE(j2.is_discarded());
+
+    std::map<std::string, std::string> firstMap;
+    std::map<std::string, std::string> secondMap;
+    collect_stable_win32_map(j1["root"], "0", firstMap);
+    collect_stable_win32_map(j2["root"], "0", secondMap);
+    if (firstMap.empty() || secondMap.empty())
+        GTEST_SKIP() << "No stable Win32 elements found for deterministic key comparison";
+
+    EXPECT_EQ(firstMap, secondMap);
+}
+
+TEST_F(NotepadFixture, QueryByIdAndDurableKey) {
+    auto lvt = get_lvt_path();
+    auto output = run_command(make_cmd(lvt, get_pid_arg()));
+    auto j = json::parse(output, nullptr, false);
+    ASSERT_FALSE(j.is_discarded());
+
+    auto rootKey = j["root"].value("key", "");
+    ASSERT_FALSE(rootKey.empty());
+
+    auto byId = run_command(make_cmd(lvt, get_pid_arg() + " --query e0 type"));
+    EXPECT_EQ(byId.substr(0, byId.find_last_not_of("\r\n") + 1),
+              j["root"].value("type", ""));
+
+    auto byKey = run_command(make_cmd(lvt, get_pid_arg() + " --query " + cmd_escape_arg(rootKey) + " id"));
+    EXPECT_EQ(byKey.substr(0, byKey.find_last_not_of("\r\n") + 1), "e0");
 }
 
 // ---- Annotation verification (DEBUG builds only) ----

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 #include "element.h"
 #include "tree_builder.h"
+#include "element_key.h"
 #include "json_serializer.h"
 #include "watch_diff.h"
 #include "framework_detector.h"
@@ -108,6 +109,7 @@ static Element make_test_tree() {
     root.children.push_back(child);
 
     assign_element_ids(root);
+    assign_element_keys(root);
     return root;
 }
 
@@ -131,6 +133,7 @@ TEST(JsonSerializer, ElementFields) {
 
     auto& r = j["root"];
     EXPECT_EQ(r["id"], "e0");
+    EXPECT_FALSE(r["key"].get<std::string>().empty());
     EXPECT_EQ(r["type"], "Window");
     EXPECT_EQ(r["framework"], "win32");
     EXPECT_EQ(r["className"], "MyWindow");
@@ -343,6 +346,7 @@ TEST(Bounds, DefaultZero) {
 TEST(Element, DefaultValues) {
     Element el;
     EXPECT_TRUE(el.id.empty());
+    EXPECT_TRUE(el.key.empty());
     EXPECT_TRUE(el.type.empty());
     EXPECT_TRUE(el.framework.empty());
     EXPECT_TRUE(el.className.empty());
@@ -350,6 +354,111 @@ TEST(Element, DefaultValues) {
     EXPECT_TRUE(el.properties.empty());
     EXPECT_TRUE(el.children.empty());
     EXPECT_EQ(el.nativeHandle, 0u);
+}
+
+// ---- Durable element keys and lookup ----
+
+static Element key_el(const std::string& type, const std::string& name = "",
+                      uintptr_t hwnd = 0) {
+    Element el;
+    el.type = type;
+    el.framework = "win32";
+    el.className = type;
+    el.nativeHandle = hwnd;
+    if (!name.empty())
+        el.properties["Name"] = name;
+    return el;
+}
+
+TEST(ElementKeys, UniqueTypeUnaffectedByEarlierSiblingInsertion) {
+    Element root = key_el("Window");
+    root.children.push_back(key_el("Button"));
+    assign_element_keys(root);
+    auto buttonKey = root.children[0].key;
+
+    root.children.insert(root.children.begin(), key_el("Edit"));
+    assign_element_keys(root);
+
+    EXPECT_EQ(root.children[1].key, buttonKey);
+}
+
+TEST(ElementKeys, StableNameUnaffectedByEarlierDuplicateSiblingInsertion) {
+    Element root = key_el("Window");
+    root.children.push_back(key_el("Button", "Save"));
+    assign_element_keys(root);
+    auto saveKey = root.children[0].key;
+
+    root.children.insert(root.children.begin(), key_el("Button", "Cancel"));
+    assign_element_keys(root);
+
+    EXPECT_EQ(root.children[1].key, saveKey);
+    EXPECT_NE(root.children[0].key, root.children[1].key);
+}
+
+TEST(ElementKeys, DistinctNamesStayTiedAfterSwap) {
+    Element root = key_el("Window");
+    root.children.push_back(key_el("Button", "Save"));
+    root.children.push_back(key_el("Button", "Cancel"));
+    assign_element_keys(root);
+    auto saveKey = root.children[0].key;
+    auto cancelKey = root.children[1].key;
+
+    std::swap(root.children[0], root.children[1]);
+    assign_element_keys(root);
+
+    EXPECT_EQ(root.children[0].properties["Name"], "Cancel");
+    EXPECT_EQ(root.children[0].key, cancelKey);
+    EXPECT_EQ(root.children[1].properties["Name"], "Save");
+    EXPECT_EQ(root.children[1].key, saveKey);
+}
+
+TEST(ElementKeys, NativeHandlesStayTiedAfterSwap) {
+    Element root = key_el("Window");
+    root.children.push_back(key_el("Button", "", 0x1111));
+    root.children.push_back(key_el("Button", "", 0x2222));
+    assign_element_keys(root);
+    auto firstKey = root.children[0].key;
+    auto secondKey = root.children[1].key;
+
+    std::swap(root.children[0], root.children[1]);
+    assign_element_keys(root);
+
+    EXPECT_EQ(root.children[0].nativeHandle, 0x2222u);
+    EXPECT_EQ(root.children[0].key, secondKey);
+    EXPECT_EQ(root.children[1].nativeHandle, 0x1111u);
+    EXPECT_EQ(root.children[1].key, firstKey);
+}
+
+TEST(ElementLookup, ResolvesByIdAndDurableKey) {
+    Element root = key_el("Window");
+    root.children.push_back(key_el("Button", "Save"));
+    assign_element_ids(root);
+    assign_element_keys(root);
+    auto key = root.children[0].key;
+
+    EXPECT_EQ(find_element_by_ref(root, "e1"), &root.children[0]);
+    EXPECT_EQ(find_element_by_ref(root, key), &root.children[0]);
+    EXPECT_EQ(find_element_by_ref(root, "missing"), nullptr);
+}
+
+TEST(ElementLookup, GetElementPropertyBuiltinsAndDynamic) {
+    Element el = key_el("Button", "Save", 0x1234);
+    el.id = "e7";
+    el.key = "stable-key";
+    el.text = "Click";
+    el.bounds = {1, 2, 3, 4};
+    el.properties["custom"] = "value";
+
+    EXPECT_EQ(get_element_property(el, "id"), "e7");
+    EXPECT_EQ(get_element_property(el, "key"), "stable-key");
+    EXPECT_EQ(get_element_property(el, "type"), "Button");
+    EXPECT_EQ(get_element_property(el, "framework"), "win32");
+    EXPECT_EQ(get_element_property(el, "className"), "Button");
+    EXPECT_EQ(get_element_property(el, "text"), "Click");
+    EXPECT_EQ(get_element_property(el, "bounds"), "1,2,3,4");
+    EXPECT_EQ(get_element_property(el, "Name"), "Save");
+    EXPECT_EQ(get_element_property(el, "custom"), "value");
+    EXPECT_FALSE(get_element_property(el, "missing").has_value());
 }
 
 TEST(Element, TreeConstruction) {


### PR DESCRIPTION
Summary:
- Adds shared durable element keying and emits keys in JSON/XML while preserving positional eN ids.
- Resolves --element and --query by either eN id or durable key.
- Adds unit coverage for key stability and lookup plus integration two-run determinism.

Fixes #25
Supersedes #15 (PR #20)
Stacked on #16