### PR TITLE
Adopt WIL result macros with a stderr-only failure logger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ set(LVT_PUBLIC_HEADERS
     src/target.h
     src/tree_builder.h
     src/watch_diff.h
+    src/wil_diagnostics.h
     "${CMAKE_CURRENT_BINARY_DIR}/include/lvt/lvt_config.h"
 )
 
@@ -83,6 +84,7 @@ set(LVT_CORE_SOURCES
     src/screenshot.cpp
     src/module_util.cpp
     src/plugin_loader.cpp
+    src/wil_diagnostics.cpp
     src/providers/win32_provider.cpp
     src/providers/comctl_provider.cpp
 )

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,47 @@ After `lvt_tap.dll` is injected into a target process, the file is locked. You m
 
 `GetPropertyValuesChain` has strict thread affinity — it must run on the XAML UI thread. The TAP DLL uses a message-only window + `SendMessage` pattern to dispatch these calls. See [docs/tap-dll-design.md](docs/tap-dll-design.md).
 
+### Resource management: WIL everywhere
+
+No raw COM pointers, no raw handles, no manual `Release()` / `CloseHandle()` / `FreeLibrary()` / `SysFreeString()` / `CoTaskMemFree()` / `VariantClear()` / `CoUninitialize()`.
+
+| Use | Type |
+|-----|------|
+| COM interfaces | `wil::com_ptr<T>` |
+| Win32 handles | `wil::unique_handle`, `wil::unique_hmodule`, `wil::unique_hfile`, `wil::unique_event`, … |
+| GDI objects | `wil::unique_hdc`, `wil::unique_hbitmap`, `wil::unique_hgdiobj` |
+| `BSTR` / `CoTaskMem` / `VARIANT` | `wil::unique_bstr`, `wil::unique_cotaskmem`, `wil::unique_variant` |
+| `CoInitializeEx` | `wil::unique_couninitialize_call` |
+| Arbitrary scope cleanup | `wil::scope_exit` |
+
+`CoInitializeEx` is a common trap: pairing it with a `bool needUninit` and a single `CoUninitialize()` at the end leaks the apartment on every early return. Use `wil::unique_couninitialize_call`, `release()`d if the init itself failed.
+
+### Error handling: WIL result macros
+
+Internal helpers return `HRESULT` and use the macros; public boundaries keep their `bool` / `std::optional` / `Element` signatures and convert at the edge:
+
+```cpp
+static HRESULT do_work_hr(...) {
+    RETURN_IF_FAILED(factory->CreateStream(&stream));
+    RETURN_HR_IF(E_INVALIDARG, width <= 0);
+    return S_OK;
+}
+
+static bool do_work(...) {
+    return SUCCEEDED(LOG_IF_FAILED(do_work_hr(...)));
+}
+```
+
+This is not cosmetic: a bare `return false` discards the failing `HRESULT` and its location, whereas the macros report the originating file, line, function, and expression.
+
+- `lvt::install_wil_result_logger()` (in `wil_diagnostics.h`) routes those reports to **stderr**, gated on `lvt::g_debug` (`--debug`).
+- **Never write diagnostics to stdout.** stdout carries machine-readable payloads — the JSON/XML tree today, and more later. `tests/unit_tests.cpp` has `WilResultLogger` tests that enforce this.
+- At any `extern "C"` boundary, wrap the body in `CATCH_RETURN()` / `CATCH_LOG()` so exceptions never escape into a foreign runtime.
+
+### Public headers and dependency visibility
+
+Headers listed in `LVT_PUBLIC_HEADERS` are installed and consumed externally. If one uses a type from a dependency, that dependency must be linked `PUBLIC` on `lvt_core`, or consumers fail with "Cannot open include file". `lvt_public_headers_test` is a compile-only target that links `lvt_core` with no include directories of its own, so it sees exactly what an external consumer sees and catches this at build time.
+
 ## Adding a new provider
 
 1. Create `src/providers/myframework_provider.h/.cpp`
@@ -101,7 +142,7 @@ After `lvt_tap.dll` is injected into a target process, the file is locked. You m
 
 - C++20
 - No exceptions in TAP DLL code (use SEH or error codes)
-- Prefer WIL smart pointers where available
+- Use WIL smart pointers and result macros — see [Key conventions](#key-conventions)
 - Keep comments minimal — only where behavior is non-obvious
 - Use `static` for file-scope helpers
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "screenshot.h"
 #include "plugin_loader.h"
 #include "debug.h"
+#include "wil_diagnostics.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -288,6 +289,11 @@ int main(int argc, char* argv[]) {
     }
 
     auto args = parse_args(argc, argv);
+
+    // Route WIL failures to stderr now that --debug is known. stdout carries the
+    // tree payload, so diagnostics must never go there.
+    lvt::install_wil_result_logger();
+
     bool hasNonTitleTarget = args.hwnd || args.pid || !args.processName.empty();
     args.pluginOption = hasNonTitleTarget ? args.windowTitle : "";
 

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -2,6 +2,7 @@
 #include "tree_builder.h"
 #include <wil/com.h>
 #include <wil/resource.h>
+#include <wil/result.h>
 
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Graphics.Capture.h>
@@ -289,19 +290,17 @@ static void annotate_pixels(BYTE* pixels, int bmpWidth, int bmpHeight,
 }
 
 // Save BGRA pixels to PNG using WIC
-static bool save_pixels_as_png(const BYTE* pixels, int width, int height,
-                               const std::string& outputPath,
-                               const RECT* cropRect = nullptr) {
+static HRESULT save_pixels_as_png_hr(const BYTE* pixels, int width, int height,
+                                     const std::string& outputPath,
+                                     const RECT* cropRect) {
     // Scope the COM initialization so every early return below uninitializes.
     wil::unique_couninitialize_call couninit;
-    auto hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
-    if (FAILED(hr))
+    if (FAILED(CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED)))
         couninit.release();
 
     wil::com_ptr<IWICImagingFactory> factory;
-    hr = CoCreateInstance(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER,
-                          IID_PPV_ARGS(&factory));
-    if (FAILED(hr)) return false;
+    RETURN_IF_FAILED(CoCreateInstance(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER,
+                                      IID_PPV_ARGS(&factory)));
 
     int outX = 0, outY = 0, outW = width, outH = height;
     if (cropRect) {
@@ -311,7 +310,7 @@ static bool save_pixels_as_png(const BYTE* pixels, int width, int height,
         outH = static_cast<int>(cropRect->bottom - cropRect->top);
         if (outX + outW > width) outW = width - outX;
         if (outY + outH > height) outH = height - outY;
-        if (outW <= 0 || outH <= 0) return false;
+        RETURN_HR_IF(E_INVALIDARG, outW <= 0 || outH <= 0);
     }
 
     int wlen = MultiByteToWideChar(CP_UTF8, 0, outputPath.c_str(), -1, nullptr, 0);
@@ -319,51 +318,48 @@ static bool save_pixels_as_png(const BYTE* pixels, int width, int height,
     MultiByteToWideChar(CP_UTF8, 0, outputPath.c_str(), -1, wpath.data(), wlen);
 
     wil::com_ptr<IWICStream> stream;
-    hr = factory->CreateStream(&stream);
-    if (FAILED(hr)) return false;
-    hr = stream->InitializeFromFilename(wpath.c_str(), GENERIC_WRITE);
-    if (FAILED(hr)) return false;
+    RETURN_IF_FAILED(factory->CreateStream(&stream));
+    RETURN_IF_FAILED(stream->InitializeFromFilename(wpath.c_str(), GENERIC_WRITE));
 
     wil::com_ptr<IWICBitmapEncoder> encoder;
-    hr = factory->CreateEncoder(GUID_ContainerFormatPng, nullptr, &encoder);
-    if (FAILED(hr)) return false;
-    hr = encoder->Initialize(stream.get(), WICBitmapEncoderNoCache);
-    if (FAILED(hr)) return false;
+    RETURN_IF_FAILED(factory->CreateEncoder(GUID_ContainerFormatPng, nullptr, &encoder));
+    RETURN_IF_FAILED(encoder->Initialize(stream.get(), WICBitmapEncoderNoCache));
 
     wil::com_ptr<IWICBitmapFrameEncode> frame;
-    hr = encoder->CreateNewFrame(&frame, nullptr);
-    if (FAILED(hr)) return false;
-    hr = frame->Initialize(nullptr);
-    if (FAILED(hr)) return false;
-    hr = frame->SetSize(outW, outH);
-    if (FAILED(hr)) return false;
+    RETURN_IF_FAILED(encoder->CreateNewFrame(&frame, nullptr));
+    RETURN_IF_FAILED(frame->Initialize(nullptr));
+    RETURN_IF_FAILED(frame->SetSize(outW, outH));
 
     WICPixelFormatGUID pixelFormat = GUID_WICPixelFormat32bppBGRA;
-    hr = frame->SetPixelFormat(&pixelFormat);
-    if (FAILED(hr)) return false;
+    RETURN_IF_FAILED(frame->SetPixelFormat(&pixelFormat));
 
     UINT srcStride = width * 4;
     UINT outStride = outW * 4;
     const BYTE* startPixel = pixels + outY * srcStride + outX * 4;
 
     if (outX == 0 && outW == width) {
-        hr = frame->WritePixels(outH, srcStride, outH * srcStride,
-                                const_cast<BYTE*>(startPixel));
+        RETURN_IF_FAILED(frame->WritePixels(outH, srcStride, outH * srcStride,
+                                            const_cast<BYTE*>(startPixel)));
     } else {
         for (int row = 0; row < outH; row++) {
-            hr = frame->WritePixels(1, outStride, outStride,
-                                    const_cast<BYTE*>(startPixel + row * srcStride));
-            if (FAILED(hr)) break;
+            RETURN_IF_FAILED(frame->WritePixels(1, outStride, outStride,
+                                                const_cast<BYTE*>(startPixel + row * srcStride)));
         }
     }
-    if (FAILED(hr)) return false;
 
-    hr = frame->Commit();
-    if (FAILED(hr)) return false;
-    hr = encoder->Commit();
-    if (FAILED(hr)) return false;
+    RETURN_IF_FAILED(frame->Commit());
+    RETURN_IF_FAILED(encoder->Commit());
 
-    return true;
+    return S_OK;
+}
+
+static bool save_pixels_as_png(const BYTE* pixels, int width, int height,
+                               const std::string& outputPath,
+                               const RECT* cropRect = nullptr) {
+    // Convert at the boundary: LOG_IF_FAILED reports the originating file/line
+    // (on stderr, under --debug) that a bare `return false` would have lost.
+    return SUCCEEDED(LOG_IF_FAILED(
+        save_pixels_as_png_hr(pixels, width, height, outputPath, cropRect)));
 }
 
 bool capture_screenshot(HWND hwnd, const std::string& outputPath,

--- a/src/wil_diagnostics.cpp
+++ b/src/wil_diagnostics.cpp
@@ -1,0 +1,60 @@
+#include "wil_diagnostics.h"
+#include "debug.h"
+
+#include <wil/result.h>
+
+#include <cstdio>
+
+namespace lvt {
+namespace {
+
+const char* failure_type_name(wil::FailureType type) {
+    switch (type) {
+    case wil::FailureType::Exception:  return "exception";
+    case wil::FailureType::Return:     return "return";
+    case wil::FailureType::Log:        return "log";
+    case wil::FailureType::FailFast:   return "failfast";
+    }
+    return "unknown";
+}
+
+// Strip the build-machine path prefix so output is stable across machines.
+const char* short_file(const char* path) {
+    if (!path)
+        return "";
+    const char* last = path;
+    for (const char* p = path; *p; ++p) {
+        if (*p == '\\' || *p == '/')
+            last = p + 1;
+    }
+    return last;
+}
+
+void __stdcall on_wil_failure(const wil::FailureInfo& failure) noexcept {
+    if (!g_debug)
+        return;
+
+    fprintf(stderr, "lvt: [wil/%s] hr=0x%08X at %s:%u",
+            failure_type_name(failure.type),
+            static_cast<unsigned>(failure.hr),
+            short_file(failure.pszFile),
+            failure.uLineNumber);
+
+    if (failure.pszFunction)
+        fprintf(stderr, " in %s", failure.pszFunction);
+    if (failure.pszCode)
+        fprintf(stderr, " [%s]", failure.pszCode);
+    if (failure.pszMessage)
+        fwprintf(stderr, L" - %ls", failure.pszMessage);
+
+    fputc('\n', stderr);
+    fflush(stderr);
+}
+
+} // namespace
+
+void install_wil_result_logger() {
+    wil::SetResultLoggingCallback(&on_wil_failure);
+}
+
+} // namespace lvt

--- a/src/wil_diagnostics.h
+++ b/src/wil_diagnostics.h
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace lvt {
+
+// Route WIL failure reports (RETURN_IF_FAILED, LOG_IF_FAILED, CATCH_LOG, ...) to
+// stderr, gated on lvt::g_debug.
+//
+// stderr is not incidental: lvt's stdout carries machine-readable payloads (the
+// JSON/XML tree, and later the MCP JSON-RPC stream), so a diagnostic written to
+// stdout corrupts the protocol. Everything diagnostic goes to stderr.
+//
+// Call once during startup, after --debug has been parsed. Safe to call again;
+// WIL only permits installing the same callback repeatedly, never a different one.
+void install_wil_result_logger();
+
+} // namespace lvt

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -9,6 +9,9 @@
 #include "framework_detector.h"
 #include "target.h"
 #include "providers/winforms_inject.h"
+#include "wil_diagnostics.h"
+#include "debug.h"
+#include <wil/result.h>
 #include <nlohmann/json.hpp>
 #include <string>
 
@@ -980,4 +983,54 @@ TEST(PluginGraft, NormalBoundsStillWork) {
     EXPECT_EQ(root.children[0].bounds.y, 220);    // 200 + 20
     EXPECT_EQ(root.children[0].bounds.width, 80);
     EXPECT_EQ(root.children[0].bounds.height, 30);
+}
+
+// --- WIL result logger ---
+// Guards the invariant Phase 2's MCP stdio transport depends on: WIL failure
+// diagnostics go to stderr and are silent unless --debug is set.
+
+namespace {
+
+HRESULT failing_helper() {
+    RETURN_HR(E_ACCESSDENIED);
+}
+
+} // namespace
+
+TEST(WilResultLogger, SilentUnlessDebug) {
+    lvt::install_wil_result_logger();
+
+    const bool previous = lvt::g_debug;
+    lvt::g_debug = false;
+
+    testing::internal::CaptureStderr();
+    testing::internal::CaptureStdout();
+    EXPECT_EQ(failing_helper(), E_ACCESSDENIED);
+    const auto out = testing::internal::GetCapturedStdout();
+    const auto err = testing::internal::GetCapturedStderr();
+
+    lvt::g_debug = previous;
+
+    EXPECT_EQ(err.find("wil/"), std::string::npos);
+    EXPECT_TRUE(out.empty());
+}
+
+TEST(WilResultLogger, ReportsToStderrNotStdoutWhenDebug) {
+    lvt::install_wil_result_logger();
+
+    const bool previous = lvt::g_debug;
+    lvt::g_debug = true;
+
+    testing::internal::CaptureStderr();
+    testing::internal::CaptureStdout();
+    EXPECT_EQ(failing_helper(), E_ACCESSDENIED);
+    const auto out = testing::internal::GetCapturedStdout();
+    const auto err = testing::internal::GetCapturedStderr();
+
+    lvt::g_debug = previous;
+
+    // The diagnostic names the originating site, and never touches stdout.
+    EXPECT_NE(err.find("wil/return"), std::string::npos);
+    EXPECT_NE(err.find("unit_tests.cpp"), std::string::npos);
+    EXPECT_TRUE(out.empty());
 }


### PR DESCRIPTION
Completes the WIL adoption started in #24 (`com_ptr`) and #39 (`unique_*`). Those covered *resources*; this covers *error propagation*, the third leg. It also unblocks planned work that needs a guaranteed-clean stdout.

## The stderr invariant

`lvt::install_wil_result_logger()` (new `src/wil_diagnostics.{h,cpp}`) installs a `wil::SetResultLoggingCallback` that writes to **stderr** and is silent unless `--debug` is set.

stderr here is not incidental. lvt's stdout carries machine-readable payloads — the JSON/XML tree today, and an MCP JSON-RPC stream under consideration — so a diagnostic written to stdout corrupts the output. Two unit tests (`WilResultLogger.*`) enforce both halves: silent without `--debug`, and on stderr *only* with it.

Verified end-to-end, with stdout still parsing as JSON while the diagnostic lands on stderr:

```
$ lvt --hwnd 0x00010DB8 --debug --screenshot Z:\nope\out.png
lvt: [wil/return] hr=0x80070003 at screenshot.cpp:322 in lvt::save_pixels_as_png_hr
     [stream->InitializeFromFilename(wpath.c_str(), GENERIC_WRITE)]
lvt: [wil/log] hr=0x80070003 at screenshot.cpp:362 in lvt::save_pixels_as_png
     [save_pixels_as_png_hr(pixels, width, height, outputPath, cropRect)]
```

## The conversion pattern

`screenshot.cpp`'s `save_pixels_as_png` is converted as the reference specimen — it had the densest manual chain in the tree. The shape is an internal `*_hr` helper returning `HRESULT`, plus a thin boundary that converts:

```cpp
static HRESULT save_pixels_as_png_hr(...) {
    RETURN_IF_FAILED(factory->CreateStream(&stream));
    RETURN_HR_IF(E_INVALIDARG, outW <= 0 || outH <= 0);
    ...
}

static bool save_pixels_as_png(...) {
    return SUCCEEDED(LOG_IF_FAILED(save_pixels_as_png_hr(...)));
}
```

Public signatures are unchanged. The 13 bare `return false` statements previously discarded both the failing `HRESULT` and its location — that information is now reported. A subtle upside: the `WritePixels` row loop used `break` on failure and relied on `hr` surviving the loop; `RETURN_IF_FAILED` makes the exit explicit.

## Documentation

`CONTRIBUTING.md` gains the conventions so they are enforceable in review: the WIL type table, the `CoInitializeEx`/`needUninit` trap fixed in #39, the internal-`HRESULT`/boundary-`bool` pattern, the no-diagnostics-on-stdout rule, `CATCH_RETURN()` at `extern "C"` boundaries, and the public-header dependency-visibility rule that `lvt_public_headers_test` enforces.

## Validation

Rebased onto `main` after #39 merged, then re-run:

| Check | Result |
|---|---|
| `cmake --preset default` + `cmake --build build` | clean |
| `lvt_unit_tests` | **62/62 passed** (60 + 2 new) |
| `lvt_chromium_tests` | **18/18 passed** |
| `lvt_integration_tests` | **31 passed, 1 skipped** (`NotepadFixture.XamlBoundsIfDetected`) |
| stdout/stderr separation | stdout parses as JSON; `wil/` diagnostics only on stderr |
