### PR TITLE
Drive apps from lvt, and restructure the CLI around verbs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,10 +84,16 @@ Shared injection/pipe/grafting logic lives in `xaml_diag_common.cpp`.
 ## CLI usage
 
 ```
-lvt --name notepad --format xml --element e2 --depth 5
-lvt --pid 1234 --screenshot out.png
-lvt --hwnd 0x1A0B3C --frameworks
+lvt dump --name notepad --format xml --element e2 --depth 5
+lvt screenshot --pid 1234 --output out.png
+lvt frameworks --hwnd 0x1A0B3C
+lvt dump --uia --name notepad          # UI Automation tree instead
+lvt click e6 --name notepad            # drive the app
 ```
+
+lvt takes a verb first, then arguments, then options. `dump` is implied when no
+verb is given, so `lvt --name notepad` still works. Interaction verbs (`click`,
+`toggle`, `set-value`, `type`, `press-key`, `wait-for`, …) imply `--uia`.
 
 ## Dependencies
 

--- a/.github/skills/lvt/SKILL.md
+++ b/.github/skills/lvt/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: lvt
 description: >
-  Inspect running Windows application UIs using the lvt (Live Visual Tree) CLI tool.
+  Inspect and drive running Windows application UIs using the lvt (Live Visual Tree) CLI tool.
   Use this skill when you need to understand a Windows app's visual tree structure,
   read its UI Automation tree (AutomationIds, control types, supported patterns),
-  capture annotated screenshots, detect UI frameworks, or find specific UI elements
-  for verification or interaction planning.
+  capture annotated screenshots, detect UI frameworks, find specific UI elements,
+  or interact with an app by clicking, typing, toggling and waiting on its controls.
 ---
 
 # Inspect Windows application UI with lvt
@@ -19,7 +19,8 @@ Use `lvt` whenever you need to understand the visual content or structure of a r
 - **Screenshot capture** — take an annotated screenshot of an app with element IDs overlaid
 - **Framework detection** — determine which UI frameworks an app uses (Win32, ComCtl, XAML, WinUI 3)
 - **Automated UI interaction planning** — get element IDs and bounds to plan mouse clicks or keyboard input
-- **Automation identity** — get `AutomationId`s, control types, and supported patterns with `--uia` when you need to drive the app rather than just describe it
+- **Automation identity** — get `AutomationId`s, control types, and supported patterns with `--uia`
+- **Driving an app** — click, toggle, type, set values, and wait for the UI to settle
 
 ## Prerequisites
 
@@ -80,10 +81,11 @@ lvt --name notepad --output tree.json
 
 ```powershell
 # Screenshot only (no tree output)
-lvt --name notepad --screenshot out.png
+lvt screenshot --name notepad --output out.png
 
 # Screenshot + tree output together
-lvt --name notepad --screenshot out.png --dump
+lvt screenshot --name notepad --output out.png
+lvt dump --name notepad
 ```
 
 Screenshots are annotated with element IDs (e0, e1, …) overlaid on each element, making it easy to correlate visual positions with tree nodes.
@@ -94,13 +96,13 @@ When the full tree is too large, scope to a specific element:
 
 ```powershell
 # Only show element e5 and its descendants, up to 3 levels deep
-lvt --name myapp --element e5 --depth 3
+lvt dump --name myapp --element e5 --depth 3
 ```
 
 ### Detect frameworks only
 
 ```powershell
-lvt --name notepad --frameworks
+lvt frameworks --name notepad
 ```
 
 ### Get the UI Automation tree
@@ -111,13 +113,13 @@ automation client needs.
 
 ```powershell
 # Automation-grade view
-lvt --name myapp --uia
+lvt dump --uia --name myapp
 
 # Narrower (content) or wider (raw) views
-lvt --name myapp --uia --uia-view content
+lvt dump --uia --uia-view content --name myapp
 
 # Look up one element by its UIA RuntimeId
-lvt --name myapp --uia --query uia:42.3150138.4.5
+lvt query uia:42.3150138.4.5 --name myapp
 ```
 
 Prefer `--uia` when you want to answer "which control do I click, and can I?" —
@@ -128,6 +130,46 @@ element can actually do (`Invoke` = clickable, `Value` = settable text,
 `--uia` also works when the target's architecture differs from lvt's, which the
 visual tree cannot do.
 
+### Drive the app
+
+lvt can act on elements, not just read them. Every interaction verb resolves its
+`<ref>` against a UIA walk, so it implies `--uia`.
+
+```powershell
+# Click a button. Uses the Invoke pattern where possible, which does not steal
+# focus or move the cursor.
+lvt click e6 --name myapp
+
+# Flip a checkbox, set a text box, type, send a chord
+lvt toggle e7 --name myapp
+lvt set-value e4 "hello" --name myapp
+lvt type "some text" --focus-first e4 --name myapp
+lvt press-key "Ctrl+S" --name myapp
+
+# Wait for the UI to catch up before the next step
+lvt wait-for e9 --wait-prop IsEnabled=true --name myapp
+```
+
+The result JSON reports **how** the action was performed:
+
+```json
+{ "action": "click", "ok": true, "method": "InvokePattern",
+  "result": { "AutomationId": "PrimaryButton", "...": "..." } }
+```
+
+- `method` distinguishes a quiet UIA pattern from `SendInput`. Synthetic input
+  steals focus and needs the window on top; a pattern does not.
+- `result` is the element *after* the action, so the effect can be confirmed
+  without a second walk.
+- On failure `ok` is false, `error` explains whether the pattern was missing or
+  present but refused, and the exit code is non-zero.
+
+Use `SupportedPatterns` from the tree to choose the verb: `Invoke` means
+clickable, `Toggle` checkable, `Value` settable, `ExpandCollapse` expandable.
+
+After any action that changes the UI, prefer `wait-for` over sleeping, and
+address elements by durable key or `uia:<RuntimeId>` rather than `eN` when the
+tree may have changed shape.
 ## Interpreting the output
 
 ### Element IDs
@@ -160,7 +202,7 @@ These live under `properties` in JSON output:
 | `AutomationId` | Stable, developer-assigned identifier — the best handle for a control |
 | `ControlType` | UIA control type (`Button`, `Edit`, `CheckBox`, `TreeItem`, …) |
 | `SupportedPatterns` | What the element can do (`Invoke`, `Value`, `Toggle`, `ExpandCollapse`, `Scroll`, …) |
-| `RuntimeId` | Per-element handle usable as `--query uia:<RuntimeId>` |
+| `RuntimeId` | Per-element handle usable as `query uia:<RuntimeId>` |
 | `FrameworkId` | Underlying framework (`Win32`, `XAML`, `WPF`, `WinForm`, …) |
 | `IsEnabled`, `IsOffscreen`, `HasKeyboardFocus` | Whether the element is actually actionable right now |
 | `Value.Value`, `Toggle.ToggleState`, `ExpandCollapse.State` | Current state, present only when the owning pattern is supported |
@@ -200,7 +242,7 @@ Pattern state is only emitted where the pattern is supported, so the presence of
 
 1. **Start the target app** if it isn't already running
 2. **Run `lvt --name <app> --format xml`** to get a quick overview of the UI tree
-3. **Take a screenshot** with `lvt --name <app> --screenshot ui.png` to see the visual layout with element IDs
+3. **Take a screenshot** with `lvt screenshot --name <app> --output ui.png` to see the visual layout with element IDs
 4. **Drill into a subtree** with `--element <id> --depth <n>` if the tree is large
 5. **Use element IDs and bounds** to plan any UI interactions (clicks, keyboard input)
 

--- a/.github/skills/lvt/SKILL.md
+++ b/.github/skills/lvt/SKILL.md
@@ -167,9 +167,13 @@ The result JSON reports **how** the action was performed:
 Use `SupportedPatterns` from the tree to choose the verb: `Invoke` means
 clickable, `Toggle` checkable, `Value` settable, `ExpandCollapse` expandable.
 
-After any action that changes the UI, prefer `wait-for` over sleeping, and
-address elements by durable key or `uia:<RuntimeId>` rather than `eN` when the
-tree may have changed shape.
+After any action that changes the UI, prefer `wait-for` over sleeping.
+
+Choosing a reference matters when the UI changes shape: `eN` is positional and
+`uia:<RuntimeId>` is tied to the element's current host window, so expanding a
+combo box (which reparents it into a popup) invalidates both. The durable `key`
+survives. Use `eN` for one-shot commands against a static UI, and the durable
+key when acting across a structural change.
 ## Interpreting the output
 
 ### Element IDs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if(LVT_BUILD_TESTS)
     list(APPEND VCPKG_MANIFEST_FEATURES "tests")
 endif()
 
-project(lvt VERSION 0.2.0 LANGUAGES CXX)
+project(lvt VERSION 0.3.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -66,6 +66,7 @@ set(LVT_PUBLIC_HEADERS
     src/module_util.h
     src/plugin.h
     src/plugin_loader.h
+    src/input.h
     src/screenshot.h
     src/target.h
     src/tree_builder.h
@@ -84,6 +85,7 @@ set(LVT_CORE_SOURCES
     src/watch_diff.cpp
     src/screenshot.cpp
     src/module_util.cpp
+    src/input.cpp
     src/plugin_loader.cpp
     src/wil_diagnostics.cpp
     src/providers/win32_provider.cpp
@@ -110,6 +112,7 @@ if(LVT_ENABLE_UIA)
     list(APPEND LVT_CORE_SOURCES
         src/providers/uia_provider.cpp
         src/providers/uia_props.cpp
+        src/providers/uia_actions.cpp
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -598,6 +598,9 @@ target_compile_definitions(lvt_integration_tests PRIVATE
     WINUI3_SAMPLE_EXE_PATH="${WINUI3_SAMPLE_EXE_ESCAPED}"
     AVALONIA_SAMPLE_EXE_PATH="${AVALONIA_SAMPLE_EXE_ESCAPED}"
     WINFORMS_SAMPLE_EXE_PATH="${WINFORMS_SAMPLE_EXE_ESCAPED}"
+    # Lets tests assert on repository files, e.g. that the packaged skill has
+    # not drifted from the one this repo's own agent reads.
+    "LVT_SOURCE_DIR=\"${CMAKE_SOURCE_DIR}\""
 )
 target_link_libraries(lvt_integration_tests PRIVATE
     GTest::gtest GTest::gtest_main

--- a/README.md
+++ b/README.md
@@ -160,31 +160,48 @@ Instead of `lvt_copy_tap_dlls()` you can call `lvt::set_tap_directory()` at runt
 
 ### Usage
 
+lvt takes a verb, then arguments, then options. The verb defaults to `dump`.
+
 ```bash
-# Dump Notepad's visual tree as JSON
+# Dump Notepad's visual tree as JSON (dump is implied)
 lvt --name notepad
 
 # XML output
-lvt --name notepad --format xml
+lvt dump --name notepad --format xml
 
 # Capture annotated screenshot
-lvt --pid 1234 --screenshot out.png
+lvt screenshot --pid 1234 --output out.png
 
 # Just detect frameworks
-lvt --hwnd 0x1A0B3C --frameworks
+lvt frameworks --hwnd 0x1A0B3C
 
 # Scope to a subtree
-lvt --name myapp --element e5 --depth 3
+lvt dump --name myapp --element e5 --depth 3
 
 # Query an element by durable key or eN id
-lvt --name myapp --query "win32|Window|MyWindow/win32|Button|Button|Name:OK" text
-
-# Screenshot + tree dump together
-lvt --name notepad --screenshot out.png --dump
+lvt query "win32|Window|MyWindow/win32|Button|Button|Name:OK" text --name myapp
 
 # Watch for live tree changes as JSON diff events
-lvt --name notepad --watch --interval 250
+lvt watch --name notepad --interval 250
 ```
+
+Driving an app is the same shape — see [Interaction](#interaction) for the full list:
+
+```bash
+lvt click e6 --name myapp
+lvt set-value e4 "hello" --name myapp
+lvt wait-for e9 --wait-prop IsEnabled=true --name myapp
+```
+
+### Verbs
+
+| Verb | Description |
+|------|-------------|
+| `dump` | Output the element tree (default when no verb is given) |
+| `screenshot` | Capture an annotated PNG to `--output` |
+| `frameworks` | List the UI frameworks the target uses |
+| `watch` | Emit live JSON tree diff events until Ctrl+C |
+| `query <ref> [prop]` | Output one element, or one of its properties |
 
 ### Options
 
@@ -194,20 +211,19 @@ lvt --name notepad --watch --interval 250
 | `--pid <pid>` | Target process by PID |
 | `--name <exe>` | Target by process name (e.g. `notepad` or `notepad.exe`) |
 | `--title <text>` | Target by window title substring |
-| `--output <file>` | Write tree to file instead of stdout |
+| `--output <file>` | Write to a file instead of stdout, or the PNG path for `screenshot` |
 | `--format <fmt>` | `json` (default) or `xml` |
-| `--screenshot <file>` | Capture annotated screenshot to PNG |
-| `--dump` | Output the tree (default unless `--screenshot` is used) |
-| `--watch` | Emit live JSON tree diff events until Ctrl+C |
-| `--interval <ms>` | Polling interval for `--watch` (default: 500) |
+| `--interval <ms>` | Polling interval for `watch` (default: 500) |
 | `--element <ref>` | Scope to a specific element subtree by positional `eN` id, durable key, or `uia:<RuntimeId>` |
-| `--query <ref> [prop]` | Output an element, or one property, by positional `eN` id, durable key, or `uia:<RuntimeId>` |
-| `--uia` | Emit the UI Automation tree instead of the visual tree |
+| `--uia` | Use the UI Automation tree instead of the visual tree |
 | `--uia-view <view>` | UIA tree view: `control` (default), `raw`, or `content` |
 | `--uia-props <list>` | Comma-separated extra UIA properties to include |
 | `--uia-timeout <ms>` | Walk deadline (default: 10000). Caps how long UIA waits for any single provider response, and the traversal itself; a truncated tree is marked with a `Truncated` property on its root. `0` removes lvt's deadline, leaving UIA's own 20s default |
-| `--frameworks` | Just list detected frameworks |
 | `--depth <n>` | Max tree traversal depth |
+
+> **Upgrading from 0.2.x:** `--dump`, `--screenshot`, `--frameworks`, `--watch` and
+> `--query` are now verbs. Running the old flag prints the replacement. Target and
+> output flags are unchanged, and `lvt --name notepad` still dumps the tree.
 
 ## UI Automation tree (`--uia`)
 
@@ -217,16 +233,16 @@ the identifiers an automation client needs:
 
 ```powershell
 # Automation-grade view of an app
-lvt --name myapp --uia
+lvt dump --uia --name myapp
 
 # Everything UIA can see, including framework scaffolding
-lvt --name myapp --uia --uia-view raw
+lvt dump --uia --uia-view raw --name myapp
 
 # Add properties that are not in the default set
-lvt --name myapp --uia --uia-props ProviderDescription,IsPassword
+lvt dump --uia --uia-props ProviderDescription,IsPassword --name myapp
 
 # Address an element by its UIA RuntimeId
-lvt --name myapp --uia --query uia:42.3150138.4.5 AutomationId
+lvt query uia:42.3150138.4.5 AutomationId --name myapp
 ```
 
 Elements report `AutomationId`, `ControlType`, `LocalizedControlType`,
@@ -254,7 +270,7 @@ is not restricted to processes matching lvt's own architecture:
 
 ```powershell
 # x64 lvt.exe reading a 32-bit process — refused for the visual tree, fine for UIA
-lvt --pid 51748 --uia
+lvt dump --uia --pid 51748
 ```
 
 ### Relationship to the visual tree
@@ -264,6 +280,68 @@ framework-native APIs and never depends on UIA. `--uia` **replaces** it for that
 invocation rather than enriching it — the two are separate views of the same
 window. Reach for the visual tree for framework-native structure and internals,
 and `--uia` when you need automation identity and actionable state.
+
+## Interaction
+
+lvt can also *drive* an app. Every interaction verb implies `--uia`, because
+element references are resolved against a UIA walk and acting needs the patterns
+only that view exposes.
+
+```bash
+lvt click e6 --name myapp                 # Invoke, else default action, else a real click
+lvt toggle e7 --name myapp                # flip a checkbox
+lvt set-value e4 "hello" --name myapp     # text, or a numeric slider/spinner value
+lvt press-key "Ctrl+S" --name myapp       # or "Enter;Tab" for a sequence
+lvt wait-for e9 --wait-prop IsEnabled=true --name myapp
+```
+
+| Verb | Pattern used | Falls back to |
+|------|--------------|---------------|
+| `click <ref>` | `Invoke`, then `LegacyIAccessible.DoDefaultAction` | synthetic click |
+| `right-click <ref>` / `double-click <ref>` | — | always synthetic |
+| `invoke <ref>` | `Invoke` only | nothing; fails instead |
+| `toggle <ref>` | `Toggle` | — |
+| `set-value <ref> <text>` | `Value`, then `RangeValue` for numbers | focus + select-all + type |
+| `expand` / `collapse <ref>` | `ExpandCollapse` | — |
+| `select <ref>` | `SelectionItem.Select` | — |
+| `add-to-selection` / `remove-from-selection <ref>` | `SelectionItem` | — |
+| `select-text <ref> [text]` | `Text.FindText` + `Select` | — |
+| `focus <ref>` | `SetFocus` | — |
+| `scroll <ref> <dir>` | `Scroll`, then `ScrollItem.ScrollIntoView` | mouse wheel |
+| `type <text>` | — | synthetic; `--focus-first <ref>` to target |
+| `press-key <chord>` | — | synthetic |
+| `close` / `minimize` / `maximize` / `restore [<ref>]` | `Window` | — |
+| `wait-for` / `wait-gone <ref>` | polls a walk | — |
+
+**Pattern first, input second.** A UIA pattern does not steal focus, does not move
+the cursor, and works when the window is not on top. Synthetic input does all
+three, so it is only used when nothing else will do the job. The result JSON
+reports which was used:
+
+```json
+{ "action": "click", "ok": true, "method": "InvokePattern",
+  "result": { "AutomationId": "PrimaryButton", ... } }
+```
+
+`result` is the element *after* the action, so you can confirm the effect without
+a second walk. On failure, `error` says whether the pattern was missing or present
+but refused.
+
+**Virtualized items** are realized automatically — an item in a long list does not
+exist as an element until then, and `method` reports `VirtualizedItem.Realize+…`
+when that happened.
+
+**Waiting.** `wait-for` blocks until an element appears, or with `--wait-prop
+<name>=<value>` until it reports that value; `wait-gone` waits for it to
+disappear. Both stop at `--wait-timeout` (default 5000 ms) and exit non-zero on
+timeout, so a script can branch on it.
+
+**Repeating an action** is just repeating the command — there is no repeat count,
+since only the OS-interpreted sequences (double-click, key chords) need precise
+timing, and those are their own verbs. When repeating against content that
+*changes shape*, such as scrolling a virtualized list, address elements by durable
+key or `uia:<RuntimeId>` rather than `eN`: `eN` is positional, so it is stable
+only while the tree is.
 
 ## Output format
 

--- a/README.md
+++ b/README.md
@@ -338,10 +338,14 @@ timeout, so a script can branch on it.
 
 **Repeating an action** is just repeating the command — there is no repeat count,
 since only the OS-interpreted sequences (double-click, key chords) need precise
-timing, and those are their own verbs. When repeating against content that
-*changes shape*, such as scrolling a virtualized list, address elements by durable
-key or `uia:<RuntimeId>` rather than `eN`: `eN` is positional, so it is stable
-only while the tree is.
+timing, and those are their own verbs.
+
+**Choosing a reference.** `eN` is positional and `uia:<RuntimeId>` is tied to the
+element's current host window, so both can break when the UI changes *shape* —
+not merely its values. Expanding a combo box, for instance, reparents it into a
+popup: its `eN` moves and its `RuntimeId` changes, while its durable key does
+not. Use `eN` for one-shot commands against a static UI, and the **durable key**
+for anything that acts across a structural change.
 
 ## Output format
 

--- a/skills/lvt/SKILL.md
+++ b/skills/lvt/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: lvt
 description: >
-  Inspect running Windows application UIs using the lvt (Live Visual Tree) CLI tool.
+  Inspect and drive running Windows application UIs using the lvt (Live Visual Tree) CLI tool.
   Use this skill when you need to understand a Windows app's visual tree structure,
-  capture annotated screenshots, detect UI frameworks, or find specific UI elements
-  for verification or interaction planning.
+  read its UI Automation tree (AutomationIds, control types, supported patterns),
+  capture annotated screenshots, detect UI frameworks, find specific UI elements,
+  or interact with an app by clicking, typing, toggling and waiting on its controls.
 ---
 
 # Inspect Windows application UI with lvt
@@ -16,21 +17,22 @@ Use `lvt` whenever you need to understand the visual content or structure of a r
 - **UI verification** — confirm that a UI change was applied correctly (e.g. a button label changed, a dialog appeared)
 - **Finding UI elements** — locate a specific control, menu item, or text field in an app's visual tree
 - **Screenshot capture** — take an annotated screenshot of an app with element IDs overlaid
-- **Framework detection** — determine which UI frameworks an app uses (Win32, ComCtl, XAML, WinUI 3, WPF, Chromium)
+- **Framework detection** — determine which UI frameworks an app uses (Win32, ComCtl, XAML, WinUI 3)
 - **Automated UI interaction planning** — get element IDs and bounds to plan mouse clicks or keyboard input
+- **Automation identity** — get `AutomationId`s, control types, and supported patterns with `--uia`
+- **Driving an app** — click, toggle, type, set values, and wait for the UI to settle
 
 ## Prerequisites
 
-Before using lvt, ensure `lvt.exe` and `lvt_tap_{arch}.dll` are available. If they are not already on PATH or in the current directory, download and extract them automatically:
+Before using lvt, ensure `lvt.exe` and `lvt_tap.dll` are available. If they are not already on PATH or in the current directory, download and extract them automatically:
 
 ```powershell
-# Download the latest release zip (matching host architecture) and extract to ~/.lvt
+# Download the latest release zip and extract to ~/.lvt
 $lvtDir = "$env:USERPROFILE\.lvt"
 if (-not (Test-Path "$lvtDir\lvt.exe")) {
   New-Item -ItemType Directory -Path $lvtDir -Force | Out-Null
-  $arch = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } elseif ($env:PROCESSOR_ARCHITECTURE -eq "x86") { "x86" } else { "x64" }
   $release = Invoke-RestMethod "https://api.github.com/repos/asklar/lvt/releases/latest"
-  $asset = $release.assets | Where-Object { $_.name -like "lvt-*-$arch.zip" } | Select-Object -First 1
+  $asset = $release.assets | Where-Object { $_.name -like "lvt-*-x64.zip" } | Select-Object -First 1
   $zip = "$env:TEMP\lvt.zip"
   Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $zip
   Expand-Archive -Path $zip -DestinationPath $lvtDir -Force
@@ -79,10 +81,11 @@ lvt --name notepad --output tree.json
 
 ```powershell
 # Screenshot only (no tree output)
-lvt --name notepad --screenshot out.png
+lvt screenshot --name notepad --output out.png
 
 # Screenshot + tree output together
-lvt --name notepad --screenshot out.png --dump
+lvt screenshot --name notepad --output out.png
+lvt dump --name notepad
 ```
 
 Screenshots are annotated with element IDs (e0, e1, …) overlaid on each element, making it easy to correlate visual positions with tree nodes.
@@ -93,15 +96,84 @@ When the full tree is too large, scope to a specific element:
 
 ```powershell
 # Only show element e5 and its descendants, up to 3 levels deep
-lvt --name myapp --element e5 --depth 3
+lvt dump --name myapp --element e5 --depth 3
 ```
 
 ### Detect frameworks only
 
 ```powershell
-lvt --name notepad --frameworks
+lvt frameworks --name notepad
 ```
 
+### Get the UI Automation tree
+
+Use `--uia` when you need to *act on* the app rather than just describe it. It
+emits the UI Automation tree, where elements carry the identifiers and state an
+automation client needs.
+
+```powershell
+# Automation-grade view
+lvt dump --uia --name myapp
+
+# Narrower (content) or wider (raw) views
+lvt dump --uia --uia-view content --name myapp
+
+# Look up one element by its UIA RuntimeId
+lvt query uia:42.3150138.4.5 --name myapp
+```
+
+Prefer `--uia` when you want to answer "which control do I click, and can I?" —
+`AutomationId` gives a stable handle and `SupportedPatterns` tells you what the
+element can actually do (`Invoke` = clickable, `Value` = settable text,
+`Toggle` = checkable, `ExpandCollapse` = expandable).
+
+`--uia` also works when the target's architecture differs from lvt's, which the
+visual tree cannot do.
+
+### Drive the app
+
+lvt can act on elements, not just read them. Every interaction verb resolves its
+`<ref>` against a UIA walk, so it implies `--uia`.
+
+```powershell
+# Click a button. Uses the Invoke pattern where possible, which does not steal
+# focus or move the cursor.
+lvt click e6 --name myapp
+
+# Flip a checkbox, set a text box, type, send a chord
+lvt toggle e7 --name myapp
+lvt set-value e4 "hello" --name myapp
+lvt type "some text" --focus-first e4 --name myapp
+lvt press-key "Ctrl+S" --name myapp
+
+# Wait for the UI to catch up before the next step
+lvt wait-for e9 --wait-prop IsEnabled=true --name myapp
+```
+
+The result JSON reports **how** the action was performed:
+
+```json
+{ "action": "click", "ok": true, "method": "InvokePattern",
+  "result": { "AutomationId": "PrimaryButton", "...": "..." } }
+```
+
+- `method` distinguishes a quiet UIA pattern from `SendInput`. Synthetic input
+  steals focus and needs the window on top; a pattern does not.
+- `result` is the element *after* the action, so the effect can be confirmed
+  without a second walk.
+- On failure `ok` is false, `error` explains whether the pattern was missing or
+  present but refused, and the exit code is non-zero.
+
+Use `SupportedPatterns` from the tree to choose the verb: `Invoke` means
+clickable, `Toggle` checkable, `Value` settable, `ExpandCollapse` expandable.
+
+After any action that changes the UI, prefer `wait-for` over sleeping.
+
+Choosing a reference matters when the UI changes shape: `eN` is positional and
+`uia:<RuntimeId>` is tied to the element's current host window, so expanding a
+combo box (which reparents it into a popup) invalidates both. The durable `key`
+survives. Use `eN` for one-shot commands against a static UI, and the durable
+key when acting across a structural change.
 ## Interpreting the output
 
 ### Element IDs
@@ -118,11 +190,29 @@ Every element gets a stable ID like `e0`, `e1`, `e2`, etc., assigned in depth-fi
 |----------|-------------|
 | `id` | Stable element ID (e.g. `e0`) |
 | `type` | Element type name (e.g. `Window`, `Button`, `TextBlock`) |
-| `framework` | Which framework owns this element (`win32`, `comctl`, `xaml`, `winui3`, `wpf`, `chromium`) |
+| `framework` | Which framework owns this element (`win32`, `comctl`, `xaml`, `winui3`) |
 | `className` | Win32 window class name (Win32/ComCtl elements) |
 | `text` | Visible text content or window title |
 | `bounds` | Screen-relative bounding rectangle `{x, y, width, height}` |
 | `children` | Nested child elements |
+
+### Key `--uia` element properties
+
+With `--uia`, elements carry automation identity instead of framework internals.
+These live under `properties` in JSON output:
+
+| Property | Description |
+|----------|-------------|
+| `AutomationId` | Stable, developer-assigned identifier — the best handle for a control |
+| `ControlType` | UIA control type (`Button`, `Edit`, `CheckBox`, `TreeItem`, …) |
+| `SupportedPatterns` | What the element can do (`Invoke`, `Value`, `Toggle`, `ExpandCollapse`, `Scroll`, …) |
+| `RuntimeId` | Per-element handle usable as `query uia:<RuntimeId>` |
+| `FrameworkId` | Underlying framework (`Win32`, `XAML`, `WPF`, `WinForm`, …) |
+| `IsEnabled`, `IsOffscreen`, `HasKeyboardFocus` | Whether the element is actually actionable right now |
+| `Value.Value`, `Toggle.ToggleState`, `ExpandCollapse.State` | Current state, present only when the owning pattern is supported |
+
+Pattern state is only emitted where the pattern is supported, so the presence of
+`Toggle.ToggleState` is itself a reliable signal that the element is checkable.
 
 ### JSON example
 
@@ -156,7 +246,7 @@ Every element gets a stable ID like `e0`, `e1`, `e2`, etc., assigned in depth-fi
 
 1. **Start the target app** if it isn't already running
 2. **Run `lvt --name <app> --format xml`** to get a quick overview of the UI tree
-3. **Take a screenshot** with `lvt --name <app> --screenshot ui.png` to see the visual layout with element IDs
+3. **Take a screenshot** with `lvt screenshot --name <app> --output ui.png` to see the visual layout with element IDs
 4. **Drill into a subtree** with `--element <id> --depth <n>` if the tree is large
 5. **Use element IDs and bounds** to plan any UI interactions (clicks, keyboard input)
 
@@ -166,25 +256,4 @@ Every element gets a stable ID like `e0`, `e1`, `e2`, etc., assigned in depth-fi
 - If the tree is very large, use `--depth` to limit traversal depth first, then drill deeper with `--element`
 - Element IDs change between invocations if the UI structure changes — always re-query before acting on stale IDs
 - The tool requires no special permissions beyond being able to read the target process (same user session)
-- For XAML/WinUI 3 apps, lvt injects a helper DLL into the target — this is safe and non-destructive but means `lvt_tap_{arch}.dll` must be next to `lvt.exe`
-- For WPF apps, lvt injects `lvt_wpf_tap_{arch}.dll` and the managed `LvtWpfTap.dll` — both must be next to `lvt.exe`
-- lvt.exe must match the target process architecture (x64, x86, or ARM64) — a clear error is shown on mismatch. Use `lvt-x86.exe` for 32-bit WPF apps.
-
-## Chrome/Edge DOM inspection (optional one-time setup)
-
-lvt can dump the DOM tree of web pages in Chrome and Edge. This requires a one-time setup:
-
-```powershell
-$lvtDir = "$env:USERPROFILE\.lvt"
-
-# 1. Register the native messaging host for Chrome and Edge
-& "$lvtDir\plugins\chromium\lvt_chromium_host.exe" --register
-
-# 2. Load the browser extension in Chrome or Edge:
-#    - Open chrome://extensions (or edge://extensions)
-#    - Enable "Developer mode"
-#    - Click "Load unpacked" → select the extension folder:
-Start-Process "$lvtDir\plugins\chromium\extension"
-```
-
-After setup, `lvt --name chrome` or `lvt --name msedge` will include the DOM tree of the active tab. If the extension is not installed, lvt still works for all other frameworks — it just won't show web content.
+- For XAML/WinUI 3 apps, lvt injects a helper DLL into the target — this is safe and non-destructive but means `lvt_tap.dll` must be next to `lvt.exe`

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -173,12 +173,25 @@ bool parse_key_chord(const std::string& text, KeyChord& out) {
 
     // Single character: resolve through the active layout so punctuation and
     // letters both work. VkKeyScanW also reports the shift state it needs.
-    const auto wide = widen(key);
+    //
+    // That shift state means two different things, and conflating them is a
+    // bug: for a letter it merely encodes the case that was written, but for
+    // punctuation it is genuinely how the character is produced on this layout
+    // ('?' is Shift+/ on a US layout). So when the caller has written their own
+    // modifiers, resolve a letter from its lowercase form — otherwise "Ctrl+S"
+    // silently becomes Ctrl+Shift+S, which is a different shortcut in most
+    // applications. Punctuation still keeps the layout's shift, since dropping
+    // it would produce the wrong character entirely.
+    const bool hasWrittenModifiers = !modifierPart.empty();
+    const bool isLetter = key.size() == 1 && std::isalpha(static_cast<unsigned char>(key[0])) != 0;
+    const auto wide = widen(hasWrittenModifiers && isLetter ? lower : key);
     if (wide.size() == 1) {
         const SHORT scan = VkKeyScanW(wide[0]);
         if (scan == -1)
             return false;
         out.vk = static_cast<WORD>(scan & 0xFF);
+        // AltGr characters report ctrl+alt here; those are how the character is
+        // reached, so they are always folded in.
         if ((scan >> 8) & 1) out.shift = true;
         if ((scan >> 8) & 2) out.ctrl = true;
         if ((scan >> 8) & 4) out.alt = true;
@@ -261,6 +274,16 @@ bool send_text(const std::string& utf8) {
     return dispatch(inputs);
 }
 
+// Poll until the window actually reaches the foreground. Every route to the
+// foreground is asynchronous and advisory, so the only trustworthy answer is
+// what the system reports afterwards — callers use this to say the click was
+// refused rather than silently landing it on the wrong window.
+static bool wait_for_foreground(HWND root) {
+    for (int i = 0; i < 20 && GetForegroundWindow() != root; ++i)
+        std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    return GetForegroundWindow() == root;
+}
+
 bool bring_to_foreground(HWND hwnd) {
     if (!IsWindow(hwnd))
         return false;
@@ -272,18 +295,76 @@ bool bring_to_foreground(HWND hwnd) {
 
     if (IsIconic(root))
         ShowWindow(root, SW_RESTORE);
-    SetForegroundWindow(root);
 
-    // SetForegroundWindow is advisory: the shell refuses it when the calling
-    // process does not own the foreground. Give the change a moment to land and
-    // report whether it actually did, so callers can say so rather than
-    // silently clicking the wrong window.
-    for (int i = 0; i < 20 && GetForegroundWindow() != root; ++i)
-        std::this_thread::sleep_for(std::chrono::milliseconds(25));
-    return GetForegroundWindow() == root;
+    if (SetForegroundWindow(root))
+        return wait_for_foreground(root);
+
+    // SetForegroundWindow is advisory: the shell refuses a process that does
+    // not already own the foreground. That is the normal case for lvt — an
+    // agent driving an app is never the active window — so without a second
+    // attempt every synthetic click would fail with "could not bring the
+    // target window to the foreground".
+    //
+    // Attaching our input queue to the current foreground thread's makes the
+    // shell treat this process as part of that input context, which is the
+    // documented way to make the call succeed. The attachment is always undone,
+    // including on an early return, because leaving two threads sharing an
+    // input queue affects their focus and capture handling.
+    const DWORD self = GetCurrentThreadId();
+    const HWND foreground = GetForegroundWindow();
+    const DWORD other = foreground ? GetWindowThreadProcessId(foreground, nullptr) : 0;
+    if (!other || other == self)
+        return wait_for_foreground(root);
+
+    if (!AttachThreadInput(self, other, TRUE))
+        return wait_for_foreground(root);
+    auto detach = wil::scope_exit([&] { AttachThreadInput(self, other, FALSE); });
+
+    SetForegroundWindow(root);
+    BringWindowToTop(root);
+    return wait_for_foreground(root);
+}
+
+// Convert screen coordinates to the 0..65535 normalized space MOUSEEVENTF_ABSOLUTE
+// uses. MOUSEEVENTF_VIRTUALDESK makes that space span all monitors, so negative
+// coordinates on a secondary display work.
+static bool to_absolute(POINT screenPoint, LONG& dx, LONG& dy) {
+    const int left = GetSystemMetrics(SM_XVIRTUALSCREEN);
+    const int top = GetSystemMetrics(SM_YVIRTUALSCREEN);
+    const int width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+    const int height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+    if (width <= 1 || height <= 1)
+        return false;
+
+    // Rounded rather than truncated: at 4K widths a truncating conversion can
+    // land a pixel short, which is enough to miss a 1px-border control.
+    const double nx = (static_cast<double>(screenPoint.x - left) * 65535.0) / (width - 1);
+    const double ny = (static_cast<double>(screenPoint.y - top) * 65535.0) / (height - 1);
+    dx = static_cast<LONG>(nx + 0.5);
+    dy = static_cast<LONG>(ny + 0.5);
+    return true;
+}
+
+bool point_is_on_screen(POINT screenPoint) {
+    return MonitorFromPoint(screenPoint, MONITOR_DEFAULTTONULL) != nullptr;
 }
 
 bool send_click(POINT screenPoint, int button, int clickCount) {
+    // Refuse rather than clamp. SetCursorPos silently pins an out-of-range
+    // point to the nearest edge and still reports success, so a click aimed at
+    // an offscreen element would land on the desktop corner — on whatever
+    // window happens to be there — and be reported as having worked.
+    if (!point_is_on_screen(screenPoint)) {
+        LOG_HR_MSG(E_INVALIDARG, "click point %ld,%ld is not on any monitor",
+                   screenPoint.x, screenPoint.y);
+        return false;
+    }
+
+    LONG dx = 0;
+    LONG dy = 0;
+    if (!to_absolute(screenPoint, dx, dy))
+        return false;
+
     POINT restore{};
     const bool haveRestore = GetCursorPos(&restore) != FALSE;
     // Put the cursor back even if a SendInput below fails.
@@ -292,30 +373,56 @@ bool send_click(POINT screenPoint, int button, int clickCount) {
             SetCursorPos(restore.x, restore.y);
     });
 
-    if (!SetCursorPos(screenPoint.x, screenPoint.y)) {
-        LOG_LAST_ERROR_MSG("SetCursorPos(%ld, %ld)", screenPoint.x, screenPoint.y);
-        return false;
-    }
-
     DWORD down = MOUSEEVENTF_LEFTDOWN, up = MOUSEEVENTF_LEFTUP;
     if (button == 1) { down = MOUSEEVENTF_RIGHTDOWN;  up = MOUSEEVENTF_RIGHTUP; }
     if (button == 2) { down = MOUSEEVENTF_MIDDLEDOWN; up = MOUSEEVENTF_MIDDLEUP; }
 
+    // The move travels in the same batch as the buttons, and every button event
+    // repeats the absolute position. SendInput only enqueues: button events
+    // without a position are resolved against wherever the cursor is when the
+    // raw input thread dequeues them, which — because the scope_exit above
+    // restores the cursor as soon as SendInput returns — can be the user's
+    // original position rather than the target. Carrying the coordinates on
+    // every event makes position and click atomic.
+    const DWORD move = MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK;
+
     std::vector<INPUT> inputs;
+    INPUT moveInput{};
+    moveInput.type = INPUT_MOUSE;
+    moveInput.mi.dwFlags = move;
+    moveInput.mi.dx = dx;
+    moveInput.mi.dy = dy;
+    inputs.push_back(moveInput);
+
     for (int i = 0; i < (std::max)(1, clickCount); ++i) {
         INPUT d{};
         d.type = INPUT_MOUSE;
-        d.mi.dwFlags = down;
+        d.mi.dwFlags = down | move;
+        d.mi.dx = dx;
+        d.mi.dy = dy;
         inputs.push_back(d);
         INPUT u{};
         u.type = INPUT_MOUSE;
-        u.mi.dwFlags = up;
+        u.mi.dwFlags = up | move;
+        u.mi.dx = dx;
+        u.mi.dy = dy;
         inputs.push_back(u);
     }
     return dispatch(inputs);
 }
 
 bool send_wheel(POINT screenPoint, int delta, bool horizontal) {
+    if (!point_is_on_screen(screenPoint)) {
+        LOG_HR_MSG(E_INVALIDARG, "scroll point %ld,%ld is not on any monitor",
+                   screenPoint.x, screenPoint.y);
+        return false;
+    }
+
+    LONG dx = 0;
+    LONG dy = 0;
+    if (!to_absolute(screenPoint, dx, dy))
+        return false;
+
     POINT restore{};
     const bool haveRestore = GetCursorPos(&restore) != FALSE;
     auto restoreCursor = wil::scope_exit([&] {
@@ -323,12 +430,15 @@ bool send_wheel(POINT screenPoint, int delta, bool horizontal) {
             SetCursorPos(restore.x, restore.y);
     });
 
-    SetCursorPos(screenPoint.x, screenPoint.y);
-
+    // Same reasoning as send_click: the wheel event carries its own position so
+    // it cannot be delivered wherever the cursor was restored to.
     INPUT input{};
     input.type = INPUT_MOUSE;
-    input.mi.dwFlags = horizontal ? MOUSEEVENTF_HWHEEL : MOUSEEVENTF_WHEEL;
+    input.mi.dwFlags = (horizontal ? MOUSEEVENTF_HWHEEL : MOUSEEVENTF_WHEEL) |
+                       MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK;
     input.mi.mouseData = static_cast<DWORD>(delta);
+    input.mi.dx = dx;
+    input.mi.dy = dy;
     std::vector<INPUT> inputs{input};
     return dispatch(inputs);
 }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1,0 +1,336 @@
+#include "input.h"
+#include "debug.h"
+
+#include <wil/result.h>
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <thread>
+#include <unordered_map>
+
+namespace lvt {
+namespace {
+
+std::string to_lower(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return s;
+}
+
+std::string trim(const std::string& s) {
+    const size_t first = s.find_first_not_of(" \t");
+    if (first == std::string::npos)
+        return {};
+    const size_t last = s.find_last_not_of(" \t");
+    return s.substr(first, last - first + 1);
+}
+
+// Named keys. Single characters and digits are resolved separately via
+// VkKeyScan so "a" and "7" work without an entry each.
+const std::unordered_map<std::string, WORD>& key_names() {
+    static const std::unordered_map<std::string, WORD> names = {
+        {"enter", VK_RETURN},   {"return", VK_RETURN},
+        {"tab", VK_TAB},        {"esc", VK_ESCAPE},      {"escape", VK_ESCAPE},
+        {"space", VK_SPACE},    {"spacebar", VK_SPACE},
+        {"backspace", VK_BACK}, {"back", VK_BACK},
+        {"delete", VK_DELETE},  {"del", VK_DELETE},
+        {"insert", VK_INSERT},  {"ins", VK_INSERT},
+        {"home", VK_HOME},      {"end", VK_END},
+        {"pageup", VK_PRIOR},   {"pgup", VK_PRIOR},
+        {"pagedown", VK_NEXT},  {"pgdn", VK_NEXT},
+        {"up", VK_UP},          {"down", VK_DOWN},
+        {"left", VK_LEFT},      {"right", VK_RIGHT},
+        {"printscreen", VK_SNAPSHOT},
+        {"apps", VK_APPS},      {"menu", VK_APPS},
+        {"capslock", VK_CAPITAL},
+    };
+    return names;
+}
+
+bool is_extended_key(WORD vk) {
+    // Extended keys need KEYEVENTF_EXTENDEDKEY or they map to the numpad.
+    switch (vk) {
+    case VK_INSERT: case VK_DELETE: case VK_HOME: case VK_END:
+    case VK_PRIOR:  case VK_NEXT:   case VK_UP:   case VK_DOWN:
+    case VK_LEFT:   case VK_RIGHT:  case VK_SNAPSHOT: case VK_APPS:
+    case VK_LWIN:   case VK_RWIN:
+        return true;
+    default:
+        return false;
+    }
+}
+
+void append_key(std::vector<INPUT>& inputs, WORD vk, bool up) {
+    INPUT input{};
+    input.type = INPUT_KEYBOARD;
+    input.ki.wVk = vk;
+    input.ki.dwFlags = (up ? KEYEVENTF_KEYUP : 0) |
+                       (is_extended_key(vk) ? KEYEVENTF_EXTENDEDKEY : 0);
+    inputs.push_back(input);
+}
+
+bool dispatch(std::vector<INPUT>& inputs) {
+    if (inputs.empty())
+        return true;
+    const UINT sent = SendInput(static_cast<UINT>(inputs.size()), inputs.data(), sizeof(INPUT));
+    if (sent != inputs.size()) {
+        LOG_LAST_ERROR_MSG("SendInput sent %u of %zu events", sent, inputs.size());
+        return false;
+    }
+    return true;
+}
+
+std::wstring widen(const std::string& text) {
+    if (text.empty())
+        return {};
+    const int needed = MultiByteToWideChar(CP_UTF8, 0, text.c_str(),
+                                           static_cast<int>(text.size()), nullptr, 0);
+    if (needed <= 0)
+        return {};
+    std::wstring out(static_cast<size_t>(needed), L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, text.c_str(), static_cast<int>(text.size()),
+                        out.data(), needed);
+    return out;
+}
+
+} // namespace
+
+bool parse_key_chord(const std::string& text, KeyChord& out) {
+    out = {};
+    const auto trimmed = trim(text);
+    if (trimmed.empty())
+        return false;
+
+    // '+' is both the separator and a legitimate key ("Ctrl++" zooms in), so
+    // the key is peeled off first and the rest split as modifiers. A dangling
+    // separator ("Ctrl+") is an error, not a request for the '+' key.
+    std::string keyToken;
+    std::string modifierPart;
+    if (trimmed.back() == '+') {
+        if (trimmed.size() == 1) {
+            keyToken = "+";
+        } else if (trimmed[trimmed.size() - 2] == '+') {
+            keyToken = "+";
+            modifierPart = trimmed.substr(0, trimmed.size() - 2);
+        } else {
+            return false;
+        }
+    } else {
+        const size_t lastPlus = trimmed.rfind('+');
+        if (lastPlus == std::string::npos) {
+            keyToken = trimmed;
+        } else {
+            keyToken = trimmed.substr(lastPlus + 1);
+            modifierPart = trimmed.substr(0, lastPlus);
+        }
+    }
+    if (keyToken.empty())
+        return false;
+
+    if (!modifierPart.empty()) {
+        size_t start = 0;
+        while (start <= modifierPart.size()) {
+            const size_t plus = modifierPart.find('+', start);
+            const auto token = trim(modifierPart.substr(
+                start, plus == std::string::npos ? std::string::npos : plus - start));
+            if (token.empty())
+                return false;
+            const auto lower = to_lower(token);
+            if (lower == "ctrl" || lower == "control")      out.ctrl = true;
+            else if (lower == "alt")                        out.alt = true;
+            else if (lower == "shift")                      out.shift = true;
+            else if (lower == "win" || lower == "meta")     out.win = true;
+            else return false;
+            if (plus == std::string::npos)
+                break;
+            start = plus + 1;
+        }
+    }
+
+    const auto key = trim(keyToken);
+    if (key.empty())
+        return false;
+    const auto lower = to_lower(key);
+
+    // Function keys.
+    if (lower.size() >= 2 && lower[0] == 'f' &&
+        std::all_of(lower.begin() + 1, lower.end(),
+                    [](unsigned char c) { return std::isdigit(c); })) {
+        const int n = std::atoi(lower.c_str() + 1);
+        if (n < 1 || n > 24)
+            return false;
+        out.vk = static_cast<WORD>(VK_F1 + n - 1);
+        return true;
+    }
+
+    const auto& names = key_names();
+    const auto it = names.find(lower);
+    if (it != names.end()) {
+        out.vk = it->second;
+        return true;
+    }
+
+    // Single character: resolve through the active layout so punctuation and
+    // letters both work. VkKeyScanW also reports the shift state it needs.
+    const auto wide = widen(key);
+    if (wide.size() == 1) {
+        const SHORT scan = VkKeyScanW(wide[0]);
+        if (scan == -1)
+            return false;
+        out.vk = static_cast<WORD>(scan & 0xFF);
+        if ((scan >> 8) & 1) out.shift = true;
+        if ((scan >> 8) & 2) out.ctrl = true;
+        if ((scan >> 8) & 4) out.alt = true;
+        return true;
+    }
+    return false;
+}
+
+bool parse_key_chords(const std::string& text, std::vector<KeyChord>& out) {
+    out.clear();
+    size_t start = 0;
+    while (start <= text.size()) {
+        const size_t sep = text.find_first_of(";,", start);
+        const auto piece = trim(text.substr(
+            start, sep == std::string::npos ? std::string::npos : sep - start));
+        if (!piece.empty()) {
+            KeyChord chord;
+            if (!parse_key_chord(piece, chord))
+                return false;
+            out.push_back(chord);
+        }
+        if (sep == std::string::npos)
+            break;
+        start = sep + 1;
+    }
+    return !out.empty();
+}
+
+bool send_key_chord(const KeyChord& chord) {
+    if (chord.vk == 0)
+        return false;
+
+    std::vector<INPUT> inputs;
+    if (chord.ctrl)  append_key(inputs, VK_CONTROL, false);
+    if (chord.alt)   append_key(inputs, VK_MENU, false);
+    if (chord.shift) append_key(inputs, VK_SHIFT, false);
+    if (chord.win)   append_key(inputs, VK_LWIN, false);
+
+    append_key(inputs, chord.vk, false);
+    append_key(inputs, chord.vk, true);
+
+    // Release in reverse order so the modifier state unwinds cleanly.
+    if (chord.win)   append_key(inputs, VK_LWIN, true);
+    if (chord.shift) append_key(inputs, VK_SHIFT, true);
+    if (chord.alt)   append_key(inputs, VK_MENU, true);
+    if (chord.ctrl)  append_key(inputs, VK_CONTROL, true);
+
+    return dispatch(inputs);
+}
+
+bool send_text(const std::string& utf8) {
+    const auto wide = widen(utf8);
+    if (wide.empty())
+        return utf8.empty();
+
+    std::vector<INPUT> inputs;
+    inputs.reserve(wide.size() * 2);
+    for (wchar_t ch : wide) {
+        // Unicode events carry the character directly, so the result does not
+        // depend on the target's keyboard layout. Newlines still have to be a
+        // real Return, which KEYEVENTF_UNICODE would not deliver.
+        if (ch == L'\n') {
+            append_key(inputs, VK_RETURN, false);
+            append_key(inputs, VK_RETURN, true);
+            continue;
+        }
+        if (ch == L'\r')
+            continue;
+
+        INPUT down{};
+        down.type = INPUT_KEYBOARD;
+        down.ki.wScan = ch;
+        down.ki.dwFlags = KEYEVENTF_UNICODE;
+        inputs.push_back(down);
+
+        INPUT up = down;
+        up.ki.dwFlags |= KEYEVENTF_KEYUP;
+        inputs.push_back(up);
+    }
+    return dispatch(inputs);
+}
+
+bool bring_to_foreground(HWND hwnd) {
+    if (!IsWindow(hwnd))
+        return false;
+    HWND root = GetAncestor(hwnd, GA_ROOT);
+    if (!root)
+        root = hwnd;
+    if (GetForegroundWindow() == root)
+        return true;
+
+    if (IsIconic(root))
+        ShowWindow(root, SW_RESTORE);
+    SetForegroundWindow(root);
+
+    // SetForegroundWindow is advisory: the shell refuses it when the calling
+    // process does not own the foreground. Give the change a moment to land and
+    // report whether it actually did, so callers can say so rather than
+    // silently clicking the wrong window.
+    for (int i = 0; i < 20 && GetForegroundWindow() != root; ++i)
+        std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    return GetForegroundWindow() == root;
+}
+
+bool send_click(POINT screenPoint, int button, int clickCount) {
+    POINT restore{};
+    const bool haveRestore = GetCursorPos(&restore) != FALSE;
+    // Put the cursor back even if a SendInput below fails.
+    auto restoreCursor = wil::scope_exit([&] {
+        if (haveRestore)
+            SetCursorPos(restore.x, restore.y);
+    });
+
+    if (!SetCursorPos(screenPoint.x, screenPoint.y)) {
+        LOG_LAST_ERROR_MSG("SetCursorPos(%ld, %ld)", screenPoint.x, screenPoint.y);
+        return false;
+    }
+
+    DWORD down = MOUSEEVENTF_LEFTDOWN, up = MOUSEEVENTF_LEFTUP;
+    if (button == 1) { down = MOUSEEVENTF_RIGHTDOWN;  up = MOUSEEVENTF_RIGHTUP; }
+    if (button == 2) { down = MOUSEEVENTF_MIDDLEDOWN; up = MOUSEEVENTF_MIDDLEUP; }
+
+    std::vector<INPUT> inputs;
+    for (int i = 0; i < (std::max)(1, clickCount); ++i) {
+        INPUT d{};
+        d.type = INPUT_MOUSE;
+        d.mi.dwFlags = down;
+        inputs.push_back(d);
+        INPUT u{};
+        u.type = INPUT_MOUSE;
+        u.mi.dwFlags = up;
+        inputs.push_back(u);
+    }
+    return dispatch(inputs);
+}
+
+bool send_wheel(POINT screenPoint, int delta, bool horizontal) {
+    POINT restore{};
+    const bool haveRestore = GetCursorPos(&restore) != FALSE;
+    auto restoreCursor = wil::scope_exit([&] {
+        if (haveRestore)
+            SetCursorPos(restore.x, restore.y);
+    });
+
+    SetCursorPos(screenPoint.x, screenPoint.y);
+
+    INPUT input{};
+    input.type = INPUT_MOUSE;
+    input.mi.dwFlags = horizontal ? MOUSEEVENTF_HWHEEL : MOUSEEVENTF_WHEEL;
+    input.mi.mouseData = static_cast<DWORD>(delta);
+    std::vector<INPUT> inputs{input};
+    return dispatch(inputs);
+}
+
+} // namespace lvt

--- a/src/input.h
+++ b/src/input.h
@@ -1,0 +1,48 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <Windows.h>
+
+namespace lvt {
+
+// Synthetic input, used as the fallback when a UI Automation pattern cannot
+// perform an action. These steal focus and move the cursor, so prefer the
+// pattern-based path in uia_actions.h wherever the element supports one.
+
+struct KeyChord {
+    bool ctrl = false;
+    bool alt = false;
+    bool shift = false;
+    bool win = false;
+    WORD vk = 0;
+};
+
+// Parse "Ctrl+Shift+S", "Enter", "F5", "Alt+F4". Modifier and key names are
+// case-insensitive. Returns false for an empty chord, an unknown key name, or
+// modifiers with no key.
+bool parse_key_chord(const std::string& text, KeyChord& out);
+
+// Parse a semicolon- or comma-separated sequence: "Ctrl+A;Delete".
+bool parse_key_chords(const std::string& text, std::vector<KeyChord>& out);
+
+// Press and release a chord, holding modifiers for the duration of the key.
+bool send_key_chord(const KeyChord& chord);
+
+// Type UTF-8 text as Unicode key events, so it does not depend on the current
+// keyboard layout. Goes to whatever currently has focus.
+bool send_text(const std::string& utf8);
+
+// Click at a screen point. Saves and restores the cursor position, and brings
+// the owning window forward first, because synthetic clicks land on whatever is
+// actually on top.
+bool send_click(POINT screenPoint, int button = 0, int clickCount = 1);
+
+// Wheel scroll at a screen point. Positive delta scrolls up / right.
+bool send_wheel(POINT screenPoint, int delta, bool horizontal = false);
+
+// Bring the window containing an element to the foreground. Synthetic input is
+// delivered to the foreground window, so this is a prerequisite for the
+// SendInput fallbacks rather than an action in its own right.
+bool bring_to_foreground(HWND hwnd);
+
+} // namespace lvt

--- a/src/input.h
+++ b/src/input.h
@@ -32,12 +32,23 @@ bool send_key_chord(const KeyChord& chord);
 // keyboard layout. Goes to whatever currently has focus.
 bool send_text(const std::string& utf8);
 
-// Click at a screen point. Saves and restores the cursor position, and brings
-// the owning window forward first, because synthetic clicks land on whatever is
-// actually on top.
+// Is this screen point on a monitor? Worth checking before any synthetic mouse
+// input: an offscreen UI element reports coordinates far outside the desktop,
+// and the mouse APIs clamp such a point to the nearest edge and report success,
+// so input aimed at it would silently land on an unrelated window.
+bool point_is_on_screen(POINT screenPoint);
+
+// Click at a screen point. Saves and restores the cursor position, and carries
+// the position on the button events themselves so the click cannot be delivered
+// somewhere else if the cursor moves first. Returns false if the point is not
+// on any monitor.
+//
+// Callers are responsible for bringing the target window forward: synthetic
+// clicks land on whatever is actually on top.
 bool send_click(POINT screenPoint, int button = 0, int clickCount = 1);
 
-// Wheel scroll at a screen point. Positive delta scrolls up / right.
+// Wheel scroll at a screen point. Positive delta scrolls up / right. Same
+// position guarantees as send_click.
 bool send_wheel(POINT screenPoint, int delta, bool horizontal = false);
 
 // Bring the window containing an element to the foreground. Synthetic input is

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include "wil_diagnostics.h"
 #ifdef LVT_ENABLE_UIA
 #include "providers/uia_provider.h"
+#include "providers/uia_actions.h"
 #endif
 
 #include "element_key.h"
@@ -41,64 +42,110 @@ static void print_usage() {
         "lvt - Live Visual Tree inspector\n"
         "\n"
         "Usage:\n"
-        "  lvt --hwnd <handle>  [options]\n"
-        "  lvt --pid <pid>      [options]\n"
-        "  lvt --name <exe>     [options]\n"
-        "  lvt --title <text>   [options]\n"
+        "  lvt [verb] [arguments] [options]\n"
         "\n"
-        "Options:\n"
+        "  A target is required: --hwnd, --pid, --name, or --title.\n"
+        "  The verb defaults to 'dump' when omitted.\n"
+        "\n"
+        "Inspection verbs:\n"
+        "  dump                     Output the element tree (default)\n"
+        "  screenshot               Capture an annotated PNG (see --output)\n"
+        "  frameworks               List the UI frameworks the target uses\n"
+        "  watch                    Emit live JSON tree diff events until Ctrl+C\n"
+        "  query <ref> [property]   Output one element, or one of its properties\n"
+        "\n"
+        "Interaction verbs (drive the app; each implies --uia):\n"
+        "  click <ref>              Invoke, else default action, else a real click\n"
+        "  right-click <ref>        Always a synthetic click\n"
+        "  double-click <ref>       Always a synthetic double click\n"
+        "  invoke <ref>             InvokePattern only, never a synthetic click\n"
+        "  toggle <ref>             Flip a checkbox or toggle button\n"
+        "  set-value <ref> <text>   Set a text, or numeric slider/spinner, value\n"
+        "  expand <ref> | collapse <ref>\n"
+        "  select <ref>             Select an item, replacing the selection\n"
+        "  add-to-selection <ref> | remove-from-selection <ref>\n"
+        "  select-text <ref> [text] Select a substring, or all text when omitted\n"
+        "  focus <ref>              Move keyboard focus to an element\n"
+        "  scroll <ref> <dir>       Scroll up, down, left, or right\n"
+        "  type <text>              Type text; add --focus-first <ref> to target it\n"
+        "  press-key <chord>        Send \"Ctrl+S\", or \"Enter;Tab\" for a sequence\n"
+        "  close | minimize | maximize | restore [<ref>]\n"
+        "                           Window commands; default to the target window\n"
+        "  wait-for <ref>           Block until an element appears\n"
+        "  wait-gone <ref>          Block until an element disappears\n"
+        "\n"
+        "A <ref> is an element id (e5), a durable key, or uia:<RuntimeId>.\n"
+        "\n"
+        "Target options:\n"
         "  --hwnd <handle>      Target window by HWND (hex, e.g. 0x1A0B3C)\n"
         "  --pid <pid>          Target process by PID (finds main window)\n"
         "  --name <exe>         Target by process name (e.g. notepad.exe)\n"
         "  --title <text>       Target by window title substring; with Chromium and\n"
         "                       --name/--pid/--hwnd, select tab by URL/title substring\n"
-        "  --output <file>      Write output to file instead of stdout\n"
+        "\n"
+        "Output options:\n"
+        "  --output <file>      Write to a file instead of stdout (or the PNG path)\n"
         "  --format <fmt>       Output format: json (default) or xml\n"
-        "  --screenshot <file>  Capture annotated screenshot to PNG\n"
+        "  --element <ref>      Scope the tree to one element's subtree\n"
+        "  --depth <n>          Max tree traversal depth (default: unlimited)\n"
+        "  --interval <ms>      Watch polling interval (default: 500)\n"
 #ifndef NDEBUG
         "  --annotations-json <file>  Write annotation rectangles as JSON (test hook)\n"
 #endif
-        "  --dump               Output the tree (default; implied unless --screenshot)\n"
-        "  --watch              Emit live JSON tree diff events until Ctrl+C\n"
-        "  --interval <ms>      Watch polling interval (default: 500)\n"
-        "  --element <ref>      Scope to a specific element subtree by id or key\n"
-        "  --query <ref> [prop] Output one element or one property by id or key\n"
-        "  --uia                Emit the UI Automation tree instead of the visual tree\n"
+        "\n"
+        "UI Automation options:\n"
+        "  --uia                Use the UI Automation tree instead of the visual tree\n"
         "  --uia-view <view>    UIA tree view: control (default), raw, or content\n"
         "  --uia-props <list>   Comma-separated extra UIA properties to include\n"
         "  --uia-timeout <ms>   UIA walk deadline (default: 10000; 0 leaves UIA's own)\n"
-        "  --frameworks         Just detect and list frameworks\n"
-        "  --depth <n>          Max tree traversal depth (default: unlimited)\n"
+        "\n"
+        "Interaction options:\n"
+        "  --focus-first <ref>  Focus this element before type / press-key\n"
+        "  --wait-prop <name=value>  Narrow wait-for to a property value\n"
+        "  --wait-timeout <ms>  How long wait-for / wait-gone block (default: 5000)\n"
+        "\n"
         "  --debug              Show verbose diagnostic output\n"
         "  --help               Show this help\n"
     );
 }
 
+// The verb selects what lvt does. Inspection verbs read; interaction verbs
+// drive the app. Keeping them positional makes them mutually exclusive by
+// construction, rather than by a runtime check across a dozen flags.
+enum class Verb {
+    dump, screenshot, frameworks, watch, query,
+    click, rightClick, doubleClick, invoke, toggle, setValue,
+    expand, collapse, select, addToSelection, removeFromSelection, selectText,
+    focus, scroll, type, pressKey,
+    close, minimize, maximize, restore,
+    waitFor, waitGone,
+};
+
 struct Args {
+    Verb verb = Verb::dump;
     HWND hwnd = nullptr;
     DWORD pid = 0;
     std::string processName;
     std::string windowTitle;
     std::string outputFile;
     std::string format = "json";
-    std::string screenshotFile;
 #ifndef NDEBUG
     std::string annotationsFile;
 #endif
     std::string elementId;
-    std::string queryId;
-    std::string queryProperty;
     std::string pluginOption;
+    // Positional arguments belonging to the verb, in order.
+    std::vector<std::string> verbArgs;
     bool uia = false;
     std::string uiaViewName = "control";
     std::vector<std::string> uiaProps;
     int uiaTimeoutMs = 10000;
+    std::string focusFirstRef;
+    std::string waitProperty;
+    std::string waitValue;
+    int waitTimeoutMs = 5000;
     int depth = -1;
     int intervalMs = 500;
-    bool frameworksOnly = false;
-    bool dump = false;      // explicitly requested via --dump
-    bool dumpSet = false;   // true if --dump was passed on command line
-    bool watch = false;
 };
 
 static std::vector<std::string> split_csv(const std::string& text) {
@@ -120,82 +167,210 @@ static std::vector<std::string> split_csv(const std::string& text) {
     return parts;
 }
 
+// Reject a value that is not a whole non-negative number, rather than letting
+// atoi turn a typo into 0.
+static int parse_non_negative_int(const char* text, const char* flag) {
+    char* end = nullptr;
+    const long value = strtol(text, &end, 10);
+    if (end == text || *end != '\0' || value < 0 || value > INT_MAX) {
+        fprintf(stderr, "lvt: %s must be a whole non-negative number\n", flag);
+        exit(1);
+    }
+    return static_cast<int>(value);
+}
+
+struct VerbSpec {
+    const char* name;
+    Verb verb;
+    int minArgs;
+    int maxArgs;
+    const char* usage;
+};
+
+// maxArgs of -1 means the verb takes an optional trailing argument.
+static const VerbSpec kVerbs[] = {
+    {"dump",                 Verb::dump,                0, 0, "dump"},
+    {"screenshot",           Verb::screenshot,          0, 0, "screenshot [--output <file>]"},
+    {"frameworks",           Verb::frameworks,          0, 0, "frameworks"},
+    {"watch",                Verb::watch,               0, 0, "watch"},
+    {"query",                Verb::query,               1, 2, "query <ref> [property]"},
+    {"click",                Verb::click,               1, 1, "click <ref>"},
+    {"right-click",          Verb::rightClick,          1, 1, "right-click <ref>"},
+    {"double-click",         Verb::doubleClick,         1, 1, "double-click <ref>"},
+    {"invoke",               Verb::invoke,              1, 1, "invoke <ref>"},
+    {"toggle",               Verb::toggle,              1, 1, "toggle <ref>"},
+    {"set-value",            Verb::setValue,            2, 2, "set-value <ref> <text>"},
+    {"expand",               Verb::expand,              1, 1, "expand <ref>"},
+    {"collapse",             Verb::collapse,            1, 1, "collapse <ref>"},
+    {"select",               Verb::select,              1, 1, "select <ref>"},
+    {"add-to-selection",     Verb::addToSelection,      1, 1, "add-to-selection <ref>"},
+    {"remove-from-selection", Verb::removeFromSelection, 1, 1, "remove-from-selection <ref>"},
+    {"select-text",          Verb::selectText,          1, 2, "select-text <ref> [text]"},
+    {"focus",                Verb::focus,               1, 1, "focus <ref>"},
+    {"scroll",               Verb::scroll,              2, 2, "scroll <ref> <up|down|left|right>"},
+    {"type",                 Verb::type,                1, 1, "type <text>"},
+    {"press-key",            Verb::pressKey,            1, 1, "press-key <chord>"},
+    {"close",                Verb::close,               0, 1, "close [<ref>]"},
+    {"minimize",             Verb::minimize,            0, 1, "minimize [<ref>]"},
+    {"maximize",             Verb::maximize,            0, 1, "maximize [<ref>]"},
+    {"restore",              Verb::restore,             0, 1, "restore [<ref>]"},
+    {"wait-for",             Verb::waitFor,             1, 1, "wait-for <ref>"},
+    {"wait-gone",            Verb::waitGone,            1, 1, "wait-gone <ref>"},
+};
+
+static const VerbSpec* find_verb(const std::string& name) {
+    for (const auto& spec : kVerbs) {
+        if (name == spec.name)
+            return &spec;
+    }
+    return nullptr;
+}
+
+static bool verb_drives_app(Verb verb) {
+    switch (verb) {
+    case Verb::dump: case Verb::screenshot: case Verb::frameworks:
+    case Verb::watch: case Verb::query:
+        return false;
+    default:
+        return true;
+    }
+}
+
+// These were flags before verbs existed. Failing with the replacement is far
+// more useful than "unknown argument", since the whole shape of the command
+// changed rather than just a spelling.
+static void reject_legacy_flag(const char* arg) {
+    struct Legacy { const char* flag; const char* replacement; };
+    static const Legacy kLegacy[] = {
+        {"--dump",       "the 'dump' verb (also the default): lvt dump --name <exe>"},
+        {"--screenshot", "the 'screenshot' verb: lvt screenshot --name <exe> --output <file>"},
+        {"--frameworks", "the 'frameworks' verb: lvt frameworks --name <exe>"},
+        {"--watch",      "the 'watch' verb: lvt watch --name <exe>"},
+        {"--query",      "the 'query' verb: lvt query <ref> [property] --name <exe>"},
+    };
+    for (const auto& legacy : kLegacy) {
+        if (strcmp(arg, legacy.flag) == 0) {
+            fprintf(stderr, "lvt: %s is now %s\n", legacy.flag, legacy.replacement);
+            fprintf(stderr, "lvt: run 'lvt --help' for the full verb list\n");
+            exit(1);
+        }
+    }
+}
+
 static Args parse_args(int argc, char* argv[]) {
     Args args;
+    const VerbSpec* spec = nullptr;
+
     for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
+        const char* arg = argv[i];
+
+        if (strcmp(arg, "--help") == 0 || strcmp(arg, "-h") == 0) {
             print_usage();
             exit(0);
-        } else if (strcmp(argv[i], "--hwnd") == 0 && i + 1 < argc) {
+        }
+
+        if (strncmp(arg, "--", 2) != 0) {
+            // A bare word is either the verb, when it comes first, or an
+            // argument to the verb already chosen.
+            if (!spec) {
+                spec = find_verb(arg);
+                if (!spec) {
+                    fprintf(stderr, "lvt: unknown verb '%s'\n", arg);
+                    fprintf(stderr, "lvt: run 'lvt --help' for the verb list\n");
+                    exit(1);
+                }
+                args.verb = spec->verb;
+                if (verb_drives_app(spec->verb))
+                    args.uia = true;
+                continue;
+            }
+            args.verbArgs.push_back(arg);
+            continue;
+        }
+
+        reject_legacy_flag(arg);
+
+        if (strcmp(arg, "--hwnd") == 0 && i + 1 < argc) {
             auto val = strtoull(argv[++i], nullptr, 0);
             args.hwnd = reinterpret_cast<HWND>(static_cast<uintptr_t>(val));
-        } else if (strcmp(argv[i], "--pid") == 0 && i + 1 < argc) {
+        } else if (strcmp(arg, "--pid") == 0 && i + 1 < argc) {
             args.pid = static_cast<DWORD>(strtoul(argv[++i], nullptr, 10));
-        } else if (strcmp(argv[i], "--name") == 0 && i + 1 < argc) {
+        } else if (strcmp(arg, "--name") == 0 && i + 1 < argc) {
             args.processName = argv[++i];
-        } else if (strcmp(argv[i], "--title") == 0 && i + 1 < argc) {
+        } else if (strcmp(arg, "--title") == 0 && i + 1 < argc) {
             args.windowTitle = argv[++i];
-        } else if (strcmp(argv[i], "--output") == 0 && i + 1 < argc) {
+        } else if (strcmp(arg, "--output") == 0 && i + 1 < argc) {
             args.outputFile = argv[++i];
-        } else if (strcmp(argv[i], "--format") == 0 && i + 1 < argc) {
+        } else if (strcmp(arg, "--format") == 0 && i + 1 < argc) {
             args.format = argv[++i];
-        } else if (strcmp(argv[i], "--screenshot") == 0 && i + 1 < argc) {
-            args.screenshotFile = argv[++i];
 #ifndef NDEBUG
-        } else if (strcmp(argv[i], "--annotations-json") == 0 && i + 1 < argc) {
+        } else if (strcmp(arg, "--annotations-json") == 0 && i + 1 < argc) {
             args.annotationsFile = argv[++i];
 #endif
-        } else if (strcmp(argv[i], "--element") == 0 && i + 1 < argc) {
+        } else if (strcmp(arg, "--element") == 0 && i + 1 < argc) {
             args.elementId = argv[++i];
-        } else if (strcmp(argv[i], "--query") == 0) {
-            if (i + 1 >= argc) {
-                fprintf(stderr, "lvt: --query requires an element id or key\n");
-                exit(1);
-            }
-            args.queryId = argv[++i];
-            if (i + 1 < argc && strncmp(argv[i + 1], "--", 2) != 0)
-                args.queryProperty = argv[++i];
-        } else if (strcmp(argv[i], "--depth") == 0 && i + 1 < argc) {
-            args.depth = atoi(argv[++i]);
-        } else if (strcmp(argv[i], "--uia") == 0) {
+        } else if (strcmp(arg, "--depth") == 0 && i + 1 < argc) {
+            args.depth = parse_non_negative_int(argv[++i], "--depth");
+        } else if (strcmp(arg, "--interval") == 0 && i + 1 < argc) {
+            args.intervalMs = parse_non_negative_int(argv[++i], "--interval");
+        } else if (strcmp(arg, "--uia") == 0) {
             args.uia = true;
-        } else if (strcmp(argv[i], "--uia-view") == 0 && i + 1 < argc) {
+        } else if (strcmp(arg, "--uia-view") == 0 && i + 1 < argc) {
             args.uia = true;
             args.uiaViewName = argv[++i];
-        } else if (strcmp(argv[i], "--uia-props") == 0 && i + 1 < argc) {
+        } else if (strcmp(arg, "--uia-props") == 0 && i + 1 < argc) {
             args.uia = true;
             args.uiaProps = split_csv(argv[++i]);
-        } else if (strcmp(argv[i], "--uia-timeout") == 0 && i + 1 < argc) {
+        } else if (strcmp(arg, "--uia-timeout") == 0 && i + 1 < argc) {
             args.uia = true;
-            // atoi would turn a typo into 0, which silently *disables* the
-            // deadline rather than rejecting the argument.
-            char* end = nullptr;
-            const long value = strtol(argv[++i], &end, 10);
-            if (end == argv[i] || *end != '\0' || value < 0) {
-                fprintf(stderr, "lvt: --uia-timeout must be a whole number of "
-                                "milliseconds (0 disables the deadline)\n");
+            args.uiaTimeoutMs = parse_non_negative_int(argv[++i], "--uia-timeout");
+        } else if (strcmp(arg, "--focus-first") == 0 && i + 1 < argc) {
+            args.focusFirstRef = argv[++i];
+            args.uia = true;
+        } else if (strcmp(arg, "--wait-prop") == 0 && i + 1 < argc) {
+            const std::string pair = argv[++i];
+            const size_t eq = pair.find('=');
+            if (eq == std::string::npos || eq == 0) {
+                fprintf(stderr, "lvt: --wait-prop must be <name>=<value>\n");
                 exit(1);
             }
-            args.uiaTimeoutMs = static_cast<int>(value);
-        } else if (strcmp(argv[i], "--watch") == 0) {
-            args.watch = true;
-        } else if (strcmp(argv[i], "--interval") == 0 && i + 1 < argc) {
-            args.intervalMs = atoi(argv[++i]);
-        } else if (strcmp(argv[i], "--frameworks") == 0) {
-            args.frameworksOnly = true;
-        } else if (strcmp(argv[i], "--dump") == 0) {
-            args.dump = true;
-            args.dumpSet = true;
-        } else if (strcmp(argv[i], "--debug") == 0) {
+            args.waitProperty = pair.substr(0, eq);
+            args.waitValue = pair.substr(eq + 1);
+        } else if (strcmp(arg, "--wait-timeout") == 0 && i + 1 < argc) {
+            args.waitTimeoutMs = parse_non_negative_int(argv[++i], "--wait-timeout");
+        } else if (strcmp(arg, "--debug") == 0) {
             lvt::g_debug = true;
         } else {
-            fprintf(stderr, "lvt: unknown argument '%s'\n", argv[i]);
+            fprintf(stderr, "lvt: unknown argument '%s'\n", arg);
             print_usage();
             exit(1);
         }
     }
+
+    if (!spec)
+        spec = find_verb("dump");
+
+    // A uia:<RuntimeId> reference only exists in a UIA tree, so asking for one
+    // implies that view. Without this the lookup would search the visual tree
+    // and report a confusing "not found".
+    auto impliesUia = [](const std::string& ref) {
+        return ref.rfind("uia:", 0) == 0;
+    };
+    if (impliesUia(args.elementId))
+        args.uia = true;
+    for (const auto& verbArg : args.verbArgs) {
+        if (impliesUia(verbArg))
+            args.uia = true;
+    }
+
+    const int count = static_cast<int>(args.verbArgs.size());
+    if (count < spec->minArgs || count > spec->maxArgs) {
+        fprintf(stderr, "lvt: usage: lvt %s\n", spec->usage);
+        exit(1);
+    }
     return args;
 }
+
 
 static std::vector<std::string> framework_names(const std::vector<lvt::FrameworkInfo>& frameworks) {
     std::vector<std::string> names;
@@ -402,6 +577,164 @@ static int run_watch_loop(const lvt::TargetInfo& target, const Args& args) {
     return 0;
 }
 
+// Translate a verb and its positional arguments into an action request. The
+// mapping lives here so uia_actions stays free of CLI shape.
+#ifdef LVT_ENABLE_UIA
+static bool build_action_request(const Args& args, lvt::ActionRequest& request) {
+    auto arg = [&](size_t index) -> std::string {
+        return index < args.verbArgs.size() ? args.verbArgs[index] : std::string();
+    };
+
+    switch (args.verb) {
+    case Verb::click:
+        request.kind = lvt::ActionKind::click;
+        request.elementRef = arg(0);
+        break;
+    case Verb::rightClick:
+        // No pattern expresses "right click", so this is always synthetic.
+        request.kind = lvt::ActionKind::click;
+        request.elementRef = arg(0);
+        request.button = 1;
+        request.forceSyntheticClick = true;
+        break;
+    case Verb::doubleClick:
+        request.kind = lvt::ActionKind::click;
+        request.elementRef = arg(0);
+        request.amount = 2;
+        request.forceSyntheticClick = true;
+        break;
+    case Verb::invoke:
+        request.kind = lvt::ActionKind::invoke;
+        request.elementRef = arg(0);
+        break;
+    case Verb::toggle:
+        request.kind = lvt::ActionKind::toggle;
+        request.elementRef = arg(0);
+        break;
+    case Verb::setValue:
+        request.kind = lvt::ActionKind::setValue;
+        request.elementRef = arg(0);
+        request.text = arg(1);
+        break;
+    case Verb::expand:
+        request.kind = lvt::ActionKind::expand;
+        request.elementRef = arg(0);
+        break;
+    case Verb::collapse:
+        request.kind = lvt::ActionKind::collapse;
+        request.elementRef = arg(0);
+        break;
+    case Verb::select:
+        request.kind = lvt::ActionKind::select;
+        request.elementRef = arg(0);
+        break;
+    case Verb::addToSelection:
+        request.kind = lvt::ActionKind::addToSelection;
+        request.elementRef = arg(0);
+        break;
+    case Verb::removeFromSelection:
+        request.kind = lvt::ActionKind::removeFromSelection;
+        request.elementRef = arg(0);
+        break;
+    case Verb::selectText:
+        request.kind = lvt::ActionKind::selectText;
+        request.elementRef = arg(0);
+        request.text = arg(1);
+        break;
+    case Verb::focus:
+        request.kind = lvt::ActionKind::focus;
+        request.elementRef = arg(0);
+        break;
+    case Verb::scroll:
+        request.kind = lvt::ActionKind::scroll;
+        request.elementRef = arg(0);
+        request.direction = arg(1);
+        if (request.direction != "up" && request.direction != "down" &&
+            request.direction != "left" && request.direction != "right") {
+            fprintf(stderr, "lvt: scroll direction must be up, down, left, or right\n");
+            return false;
+        }
+        break;
+    case Verb::type:
+        request.kind = lvt::ActionKind::typeText;
+        request.text = arg(0);
+        request.elementRef = args.focusFirstRef;
+        break;
+    case Verb::pressKey:
+        request.kind = lvt::ActionKind::pressKey;
+        request.text = arg(0);
+        request.elementRef = args.focusFirstRef;
+        break;
+    case Verb::close:
+    case Verb::minimize:
+    case Verb::maximize:
+    case Verb::restore:
+        request.kind = args.verb == Verb::close    ? lvt::ActionKind::windowClose
+                     : args.verb == Verb::minimize ? lvt::ActionKind::windowMinimize
+                     : args.verb == Verb::maximize ? lvt::ActionKind::windowMaximize
+                                                   : lvt::ActionKind::windowRestore;
+        // Window commands default to the target window itself, which is the
+        // root of the walk.
+        request.elementRef = args.verbArgs.empty() ? "e0" : arg(0);
+        break;
+    case Verb::waitFor:
+    case Verb::waitGone:
+        request.kind = args.verb == Verb::waitFor ? lvt::ActionKind::waitFor
+                                                  : lvt::ActionKind::waitGone;
+        request.elementRef = arg(0);
+        request.waitProperty = args.waitProperty;
+        request.waitValue = args.waitValue;
+        request.waitTimeoutMs = args.waitTimeoutMs;
+        break;
+    default:
+        return false;
+    }
+    return true;
+}
+#endif
+
+// Carry out an interaction and report the outcome as JSON on stdout, so a
+// caller can tell not just whether it worked but *how* — a UIA pattern and a
+// synthetic click have very different reliability.
+static int run_action(const lvt::TargetInfo& target, const Args& args) {
+#ifdef LVT_ENABLE_UIA
+    lvt::UiaOptions options;
+    if (!lvt::parse_uia_view(args.uiaViewName, options.view)) {
+        fprintf(stderr, "lvt: --uia-view must be raw, control, or content\n");
+        return 1;
+    }
+    options.extraProperties = args.uiaProps;
+    options.timeoutMs = args.uiaTimeoutMs;
+
+    lvt::ActionRequest request;
+    if (!build_action_request(args, request))
+        return 1;
+
+    const auto result = lvt::perform_action(target.hwnd, options, request);
+
+    nlohmann::json out;
+    out["action"] = lvt::action_kind_name(request.kind);
+    out["ok"] = result.ok;
+    if (!request.elementRef.empty())
+        out["element"] = request.elementRef;
+    if (!result.method.empty())
+        out["method"] = result.method;
+    if (!result.message.empty())
+        out["error"] = result.message;
+    if (result.hasElement)
+        out["result"] = query_element_to_json(result.element);
+
+    if (!write_output(args.outputFile, out.dump(2)))
+        return 1;
+    return result.ok ? 0 : 1;
+#else
+    (void)target; (void)args;
+    fprintf(stderr, "lvt: this build has UI Automation support compiled out "
+                    "(LVT_ENABLE_UIA=OFF), so interaction is unavailable\n");
+    return 1;
+#endif
+}
+
 int main(int argc, char* argv[]) {
     if (argc < 2) {
         print_usage();
@@ -420,16 +753,12 @@ int main(int argc, char* argv[]) {
     // Load plugins from %USERPROFILE%/.lvt/plugins/
     lvt::load_plugins();
 
-    // --dump is default unless --screenshot is specified without --dump
-    if (!args.dumpSet)
-        args.dump = args.screenshotFile.empty();
-
     if (args.intervalMs <= 0) {
         fprintf(stderr, "lvt: --interval must be greater than 0\n");
         return 1;
     }
-    if (args.watch && args.format != "json") {
-        fprintf(stderr, "lvt: --watch emits JSON events; --format must be json\n");
+    if (args.verb == Verb::watch && args.format != "json") {
+        fprintf(stderr, "lvt: watch emits JSON events; --format must be json\n");
         return 1;
     }
     if (args.format != "json" && args.format != "xml") {
@@ -513,10 +842,10 @@ int main(int argc, char* argv[]) {
     // Detect frameworks. Skipped for --uia, which reports the per-element
     // FrameworkId from UIA instead and needs no module enumeration.
     std::vector<lvt::FrameworkInfo> frameworks;
-    if (!args.uia || args.frameworksOnly)
+    if (!args.uia || args.verb == Verb::frameworks)
         frameworks = lvt::detect_frameworks(target.hwnd, target.pid);
 
-    if (args.frameworksOnly) {
+    if (args.verb == Verb::frameworks) {
         // Just print detected frameworks
         for (auto& fi : frameworks) {
             auto name = lvt::framework_display_name(fi);
@@ -529,7 +858,13 @@ int main(int argc, char* argv[]) {
         return 0;
     }
 
-    if (args.watch) {
+    if (verb_drives_app(args.verb)) {
+        auto result = run_action(target, args);
+        lvt::unload_plugins();
+        return result;
+    }
+
+    if (args.verb == Verb::watch) {
         auto result = run_watch_loop(target, args);
         lvt::unload_plugins();
         return result;
@@ -552,19 +887,23 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    if (!args.queryId.empty()) {
-        auto* queryElement = lvt::find_element_by_ref(tree, args.queryId);
+    if (args.verb == Verb::query) {
+        const std::string& queryRef = args.verbArgs[0];
+        const std::string queryProperty =
+            args.verbArgs.size() > 1 ? args.verbArgs[1] : std::string();
+
+        auto* queryElement = lvt::find_element_by_ref(tree, queryRef);
         if (!queryElement) {
-            fprintf(stderr, "lvt: element '%s' not found\n", args.queryId.c_str());
+            fprintf(stderr, "lvt: element '%s' not found\n", queryRef.c_str());
             return 1;
         }
 
         std::string queryOutput;
-        if (!args.queryProperty.empty()) {
-            auto value = lvt::get_element_property(*queryElement, args.queryProperty);
+        if (!queryProperty.empty()) {
+            auto value = lvt::get_element_property(*queryElement, queryProperty);
             if (!value) {
                 fprintf(stderr, "lvt: property '%s' not found on element '%s'\n",
-                        args.queryProperty.c_str(), args.queryId.c_str());
+                        queryProperty.c_str(), queryRef.c_str());
                 return 1;
             }
             queryOutput = *value;
@@ -585,8 +924,7 @@ int main(int argc, char* argv[]) {
         lvt::trim_to_depth(*outputRoot, args.depth);
     }
 
-    // Serialize and output tree (unless suppressed by --screenshot without --dump)
-    if (args.dump) {
+    if (args.verb == Verb::dump) {
         auto frameworkNames = framework_names(frameworks);
         // In UIA mode the module-scan framework list is not what was walked;
         // report the view actually produced instead.
@@ -605,13 +943,18 @@ int main(int argc, char* argv[]) {
             return 1;
     }
 
-    // Screenshot
-    if (!args.screenshotFile.empty()) {
-        bool ok = lvt::capture_screenshot(target.hwnd, args.screenshotFile,
-                                          &tree, args.elementId);
-        if (ok && lvt::g_debug) {
-            fprintf(stderr, "lvt: saved screenshot to %s\n", args.screenshotFile.c_str());
+    if (args.verb == Verb::screenshot) {
+        // The verb decides the intent, so --output names the PNG here just as
+        // it names the tree file for dump.
+        const std::string path = args.outputFile.empty() ? "lvt-screenshot.png"
+                                                         : args.outputFile;
+        if (!lvt::capture_screenshot(target.hwnd, path, &tree, args.elementId)) {
+            fprintf(stderr, "lvt: could not capture a screenshot of this window\n");
+            lvt::unload_plugins();
+            return 1;
         }
+        if (lvt::g_debug)
+            fprintf(stderr, "lvt: saved screenshot to %s\n", path.c_str());
     }
 
 #ifndef NDEBUG

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -187,7 +187,7 @@ struct VerbSpec {
     const char* usage;
 };
 
-// maxArgs of -1 means the verb takes an optional trailing argument.
+// Verbs with differing min/max arg counts take an optional trailing argument.
 static const VerbSpec kVerbs[] = {
     {"dump",                 Verb::dump,                0, 0, "dump"},
     {"screenshot",           Verb::screenshot,          0, 0, "screenshot [--output <file>]"},
@@ -816,6 +816,19 @@ int main(int argc, char* argv[]) {
         return 1;
     }
     if (!IsWindow(target.hwnd)) {
+        // wait-gone is the one verb whose success condition is the window
+        // being gone, so an invalid handle satisfies it rather than failing it.
+        if (args.verb == Verb::waitGone) {
+            printf("%s\n", nlohmann::json{{"action", "wait-gone"},
+                                          {"ok", true},
+                                          {"element", args.verbArgs.empty()
+                                                          ? std::string()
+                                                          : args.verbArgs[0]},
+                                          {"method", "window-closed"}}
+                               .dump(2)
+                               .c_str());
+            return 0;
+        }
         fprintf(stderr, "lvt: target HWND 0x%p is not a valid window\n",
                 static_cast<void*>(target.hwnd));
         return 1;

--- a/src/providers/uia_actions.cpp
+++ b/src/providers/uia_actions.cpp
@@ -1,0 +1,775 @@
+#include "uia_actions.h"
+#include "../debug.h"
+#include "../element_key.h"
+#include "../input.h"
+#include "../tree_builder.h"
+
+#include <wil/com.h>
+#include <wil/resource.h>
+#include <wil/result.h>
+
+#include <oleacc.h>
+#include <UIAutomation.h>
+
+#include <algorithm>
+#include <chrono>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace lvt {
+namespace {
+
+// A UIA client has thread affinity to its apartment, so every call here runs on
+// a dedicated MTA thread for the same reason the walk does.
+template <typename Fn>
+HRESULT run_on_mta(Fn&& fn) {
+    HRESULT result = E_FAIL;
+    std::thread worker([&] {
+        result = [&]() -> HRESULT {
+            try {
+                auto uninit = wil::CoInitializeEx_failfast(COINIT_MULTITHREADED);
+                return fn();
+            }
+            CATCH_RETURN();
+        }();
+    });
+    worker.join();
+    return result;
+}
+
+HRESULT create_automation(const UiaOptions& options, IUIAutomation** out) {
+    wil::com_ptr<IUIAutomation> automation;
+    HRESULT hr = CoCreateInstance(CLSID_CUIAutomation8, nullptr, CLSCTX_INPROC_SERVER,
+                                  IID_PPV_ARGS(&automation));
+    if (FAILED(hr)) {
+        LOG_IF_FAILED(hr);
+        RETURN_IF_FAILED(CoCreateInstance(CLSID_CUIAutomation, nullptr, CLSCTX_INPROC_SERVER,
+                                          IID_PPV_ARGS(&automation)));
+    }
+    if (options.timeoutMs > 0) {
+        if (auto automation2 = automation.try_query<IUIAutomation2>()) {
+            LOG_IF_FAILED(automation2->put_TransactionTimeout(
+                static_cast<DWORD>(options.timeoutMs)));
+            LOG_IF_FAILED(automation2->put_ConnectionTimeout(
+                static_cast<DWORD>((std::min)(options.timeoutMs, 2000))));
+        }
+    }
+    *out = automation.detach();
+    return S_OK;
+}
+
+// Re-find the live element by RuntimeId. The walk produces plain data, so
+// acting on an element means locating it again; RuntimeId is the handle UIA
+// provides for exactly this.
+HRESULT find_by_runtime_id(IUIAutomation* automation, HWND hwnd,
+                           const std::vector<int>& runtimeId,
+                           IUIAutomationElement** out) {
+    wil::com_ptr<IUIAutomationElement> root;
+    RETURN_IF_FAILED(automation->ElementFromHandle(hwnd, &root));
+    RETURN_HR_IF_NULL(E_FAIL, root.get());
+
+    wil::unique_variant condition;
+    SAFEARRAY* array = SafeArrayCreateVector(VT_I4, 0, static_cast<ULONG>(runtimeId.size()));
+    RETURN_HR_IF_NULL(E_OUTOFMEMORY, array);
+    condition.vt = VT_ARRAY | VT_I4;
+    condition.parray = array;  // unique_variant owns it from here
+    for (LONG i = 0; i < static_cast<LONG>(runtimeId.size()); ++i)
+        RETURN_IF_FAILED(SafeArrayPutElement(array, &i, (void*)&runtimeId[static_cast<size_t>(i)]));
+
+    wil::com_ptr<IUIAutomationCondition> byRuntimeId;
+    RETURN_IF_FAILED(automation->CreatePropertyCondition(
+        UIA_RuntimeIdPropertyId, condition, &byRuntimeId));
+
+    wil::com_ptr<IUIAutomationElement> found;
+    RETURN_IF_FAILED(root->FindFirst(TreeScope_Subtree, byRuntimeId.get(), &found));
+    if (!found) {
+        // The root itself is not covered by a Subtree search on some providers.
+        wil::unique_variant rootId;
+        if (SUCCEEDED(root->GetCurrentPropertyValue(UIA_RuntimeIdPropertyId, &rootId)) &&
+            rootId.vt == (VT_ARRAY | VT_I4)) {
+            found = root;
+        }
+    }
+    RETURN_HR_IF_NULL(HRESULT_FROM_WIN32(ERROR_NOT_FOUND), found.get());
+    *out = found.detach();
+    return S_OK;
+}
+
+POINT element_center(const Element& element) {
+    return POINT{element.bounds.x + element.bounds.width / 2,
+                 element.bounds.y + element.bounds.height / 2};
+}
+
+bool has_pattern(IUIAutomationElement* element, PATTERNID pattern) {
+    wil::com_ptr<IUnknown> unknown;
+    return SUCCEEDED(element->GetCurrentPattern(pattern, &unknown)) && unknown;
+}
+
+std::wstring widen(const std::string& text) {
+    if (text.empty())
+        return {};
+    const int needed = MultiByteToWideChar(CP_UTF8, 0, text.c_str(),
+                                           static_cast<int>(text.size()), nullptr, 0);
+    if (needed <= 0)
+        return {};
+    std::wstring out(static_cast<size_t>(needed), L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, text.c_str(), static_cast<int>(text.size()),
+                        out.data(), needed);
+    return out;
+}
+
+// --- individual actions -------------------------------------------------
+// An attempt distinguishes the two ways a pattern can decline: the element does
+// not expose it at all, or it exposes it and the call failed. Chained actions
+// like click need to move on in both cases; single-pattern actions like
+// --invoke need to report which one happened.
+struct PatternAttempt {
+    bool supported = false;
+    HRESULT hr = S_OK;
+
+    bool succeeded() const { return supported && SUCCEEDED(hr); }
+};
+
+PatternAttempt try_invoke(IUIAutomationElement* element, std::string& method) {
+    wil::com_ptr<IUIAutomationInvokePattern> invoke;
+    if (FAILED(element->GetCurrentPatternAs(UIA_InvokePatternId, IID_PPV_ARGS(&invoke))) ||
+        !invoke)
+        return {};
+    PatternAttempt attempt{true, invoke->Invoke()};
+    LOG_IF_FAILED(attempt.hr);
+    if (attempt.succeeded())
+        method = "InvokePattern";
+    return attempt;
+}
+
+PatternAttempt try_legacy_default_action(IUIAutomationElement* element, std::string& method) {
+    wil::com_ptr<IUIAutomationLegacyIAccessiblePattern> legacy;
+    if (FAILED(element->GetCurrentPatternAs(UIA_LegacyIAccessiblePatternId,
+                                            IID_PPV_ARGS(&legacy))) || !legacy)
+        return {};
+    // Nearly everything exposes LegacyIAccessible, but only some have a default
+    // action that does anything, so a failure here is routine.
+    PatternAttempt attempt{true, legacy->DoDefaultAction()};
+    LOG_IF_FAILED(attempt.hr);
+    if (attempt.succeeded())
+        method = "LegacyIAccessible.DoDefaultAction";
+    return attempt;
+}
+
+PatternAttempt try_toggle(IUIAutomationElement* element, std::string& method) {
+    wil::com_ptr<IUIAutomationTogglePattern> toggle;
+    if (FAILED(element->GetCurrentPatternAs(UIA_TogglePatternId, IID_PPV_ARGS(&toggle))) ||
+        !toggle)
+        return {};
+    PatternAttempt attempt{true, toggle->Toggle()};
+    LOG_IF_FAILED(attempt.hr);
+    if (attempt.succeeded())
+        method = "TogglePattern";
+    return attempt;
+}
+
+PatternAttempt try_set_value(IUIAutomationElement* element, const std::string& text,
+                             std::string& method) {
+    wil::com_ptr<IUIAutomationValuePattern> value;
+    if (FAILED(element->GetCurrentPatternAs(UIA_ValuePatternId, IID_PPV_ARGS(&value))) ||
+        !value)
+        return {};
+    BOOL readOnly = FALSE;
+    if (SUCCEEDED(value->get_CurrentIsReadOnly(&readOnly)) && readOnly)
+        return {};  // present but not writable: same as unavailable to a caller
+
+    wil::unique_bstr bstr(SysAllocString(widen(text).c_str()));
+    if (!bstr)
+        return {true, E_OUTOFMEMORY};
+    PatternAttempt attempt{true, value->SetValue(bstr.get())};
+    LOG_IF_FAILED(attempt.hr);
+    if (attempt.succeeded())
+        method = "ValuePattern";
+    return attempt;
+}
+
+PatternAttempt try_expand_collapse(IUIAutomationElement* element, bool expand,
+                                   std::string& method) {
+    wil::com_ptr<IUIAutomationExpandCollapsePattern> pattern;
+    if (FAILED(element->GetCurrentPatternAs(UIA_ExpandCollapsePatternId,
+                                            IID_PPV_ARGS(&pattern))) || !pattern)
+        return {};
+    PatternAttempt attempt{true, expand ? pattern->Expand() : pattern->Collapse()};
+    LOG_IF_FAILED(attempt.hr);
+    if (attempt.succeeded())
+        method = "ExpandCollapsePattern";
+    return attempt;
+}
+
+PatternAttempt try_select(IUIAutomationElement* element, std::string& method) {
+    wil::com_ptr<IUIAutomationSelectionItemPattern> pattern;
+    if (FAILED(element->GetCurrentPatternAs(UIA_SelectionItemPatternId,
+                                            IID_PPV_ARGS(&pattern))) || !pattern)
+        return {};
+    PatternAttempt attempt{true, pattern->Select()};
+    LOG_IF_FAILED(attempt.hr);
+    if (attempt.succeeded())
+        method = "SelectionItemPattern";
+    return attempt;
+}
+
+PatternAttempt try_scroll(IUIAutomationElement* element, const std::string& direction,
+                          int amount, std::string& method) {
+    wil::com_ptr<IUIAutomationScrollPattern> scroll;
+    if (SUCCEEDED(element->GetCurrentPatternAs(UIA_ScrollPatternId, IID_PPV_ARGS(&scroll))) &&
+        scroll) {
+        auto horizontal = ScrollAmount_NoAmount;
+        auto vertical = ScrollAmount_NoAmount;
+        if (direction == "up")    vertical = ScrollAmount_SmallDecrement;
+        if (direction == "down")  vertical = ScrollAmount_SmallIncrement;
+        if (direction == "left")  horizontal = ScrollAmount_SmallDecrement;
+        if (direction == "right") horizontal = ScrollAmount_SmallIncrement;
+        if (horizontal == ScrollAmount_NoAmount && vertical == ScrollAmount_NoAmount)
+            return {true, E_INVALIDARG};
+
+        HRESULT hr = S_OK;
+        for (int i = 0; i < (std::max)(1, amount) && SUCCEEDED(hr); ++i)
+            hr = scroll->Scroll(horizontal, vertical);
+        LOG_IF_FAILED(hr);
+        PatternAttempt attempt{true, hr};
+        if (attempt.succeeded())
+            method = "ScrollPattern";
+        return attempt;
+    }
+
+    // Not scrollable itself, but it may be an item inside something that is.
+    wil::com_ptr<IUIAutomationScrollItemPattern> scrollItem;
+    if (SUCCEEDED(element->GetCurrentPatternAs(UIA_ScrollItemPatternId,
+                                               IID_PPV_ARGS(&scrollItem))) && scrollItem) {
+        PatternAttempt attempt{true, scrollItem->ScrollIntoView()};
+        LOG_IF_FAILED(attempt.hr);
+        if (attempt.succeeded())
+            method = "ScrollItemPattern.ScrollIntoView";
+        return attempt;
+    }
+    return {};
+}
+
+// A virtualized item does not exist as a real element until it is realized, so
+// nothing can be done to it. Realizing first is transparent and cheap: an
+// already-real element simply does not expose the pattern.
+bool realize_if_virtualized(IUIAutomationElement* element) {
+    wil::com_ptr<IUIAutomationVirtualizedItemPattern> virtualized;
+    if (FAILED(element->GetCurrentPatternAs(UIA_VirtualizedItemPatternId,
+                                            IID_PPV_ARGS(&virtualized))) || !virtualized)
+        return false;
+    LOG_IF_FAILED(virtualized->Realize());
+    return true;
+}
+
+PatternAttempt try_set_range_value(IUIAutomationElement* element, const std::string& text,
+                                   std::string& method) {
+    wil::com_ptr<IUIAutomationRangeValuePattern> range;
+    if (FAILED(element->GetCurrentPatternAs(UIA_RangeValuePatternId, IID_PPV_ARGS(&range))) ||
+        !range)
+        return {};
+    BOOL readOnly = FALSE;
+    if (SUCCEEDED(range->get_CurrentIsReadOnly(&readOnly)) && readOnly)
+        return {};
+
+    char* end = nullptr;
+    const double value = strtod(text.c_str(), &end);
+    if (end == text.c_str() || *end != '\0')
+        return {};  // not a number, so RangeValue is not what the caller meant
+
+    PatternAttempt attempt{true, range->SetValue(value)};
+    LOG_IF_FAILED(attempt.hr);
+    if (attempt.succeeded())
+        method = "RangeValuePattern";
+    return attempt;
+}
+
+PatternAttempt try_change_selection(IUIAutomationElement* element, bool add,
+                                    std::string& method) {
+    wil::com_ptr<IUIAutomationSelectionItemPattern> pattern;
+    if (FAILED(element->GetCurrentPatternAs(UIA_SelectionItemPatternId,
+                                            IID_PPV_ARGS(&pattern))) || !pattern)
+        return {};
+    PatternAttempt attempt{true, add ? pattern->AddToSelection()
+                                     : pattern->RemoveFromSelection()};
+    LOG_IF_FAILED(attempt.hr);
+    if (attempt.succeeded())
+        method = add ? "SelectionItemPattern.AddToSelection"
+                     : "SelectionItemPattern.RemoveFromSelection";
+    return attempt;
+}
+
+PatternAttempt try_select_text(IUIAutomationElement* element, const std::string& needle,
+                               std::string& method) {
+    wil::com_ptr<IUIAutomationTextPattern> text;
+    if (FAILED(element->GetCurrentPatternAs(UIA_TextPatternId, IID_PPV_ARGS(&text))) || !text)
+        return {};
+
+    wil::com_ptr<IUIAutomationTextRange> document;
+    if (FAILED(text->get_DocumentRange(&document)) || !document)
+        return {true, E_FAIL};
+
+    if (needle.empty()) {
+        PatternAttempt attempt{true, document->Select()};
+        LOG_IF_FAILED(attempt.hr);
+        if (attempt.succeeded())
+            method = "TextPattern.SelectAll";
+        return attempt;
+    }
+
+    wil::unique_bstr wanted(SysAllocString(widen(needle).c_str()));
+    if (!wanted)
+        return {true, E_OUTOFMEMORY};
+
+    wil::com_ptr<IUIAutomationTextRange> found;
+    if (FAILED(document->FindText(wanted.get(), FALSE, FALSE, &found)) || !found)
+        return {true, HRESULT_FROM_WIN32(ERROR_NOT_FOUND)};
+
+    PatternAttempt attempt{true, found->Select()};
+    LOG_IF_FAILED(attempt.hr);
+    if (attempt.succeeded())
+        method = "TextPattern.Select";
+    return attempt;
+}
+
+PatternAttempt try_window_action(IUIAutomationElement* element, ActionKind kind,
+                                 std::string& method) {
+    wil::com_ptr<IUIAutomationWindowPattern> window;
+    if (FAILED(element->GetCurrentPatternAs(UIA_WindowPatternId, IID_PPV_ARGS(&window))) ||
+        !window)
+        return {};
+
+    if (kind == ActionKind::windowClose) {
+        PatternAttempt attempt{true, window->Close()};
+        LOG_IF_FAILED(attempt.hr);
+        if (attempt.succeeded())
+            method = "WindowPattern.Close";
+        return attempt;
+    }
+
+    WindowVisualState state = WindowVisualState_Normal;
+    if (kind == ActionKind::windowMinimize) state = WindowVisualState_Minimized;
+    if (kind == ActionKind::windowMaximize) state = WindowVisualState_Maximized;
+
+    BOOL canDo = TRUE;
+    if (kind == ActionKind::windowMinimize)
+        LOG_IF_FAILED(window->get_CurrentCanMinimize(&canDo));
+    if (kind == ActionKind::windowMaximize)
+        LOG_IF_FAILED(window->get_CurrentCanMaximize(&canDo));
+    if (!canDo)
+        return {true, HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)};
+
+    PatternAttempt attempt{true, window->SetWindowVisualState(state)};
+    LOG_IF_FAILED(attempt.hr);
+    if (attempt.succeeded())
+        method = "WindowPattern.SetWindowVisualState";
+    return attempt;
+}
+
+// Turn a declined attempt into something a caller can act on.
+std::string describe_decline(const PatternAttempt& attempt, const char* patternName) {
+    if (!attempt.supported)
+        return std::string("element does not support the ") + patternName + " pattern";
+    char buf[32];
+    snprintf(buf, sizeof(buf), "0x%08X", static_cast<unsigned>(attempt.hr));
+    return std::string("the ") + patternName + " pattern is present but the call failed (" +
+           buf + ")";
+}
+
+} // namespace
+
+bool parse_action_kind(const std::string& name, ActionKind& out) {
+    std::string lower = name;
+    std::transform(lower.begin(), lower.end(), lower.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    if (lower == "click")      { out = ActionKind::click;    return true; }
+    if (lower == "invoke")     { out = ActionKind::invoke;   return true; }
+    if (lower == "toggle")     { out = ActionKind::toggle;   return true; }
+    if (lower == "setvalue" || lower == "set-value") { out = ActionKind::setValue; return true; }
+    if (lower == "expand")     { out = ActionKind::expand;   return true; }
+    if (lower == "collapse")   { out = ActionKind::collapse; return true; }
+    if (lower == "select")     { out = ActionKind::select;   return true; }
+    if (lower == "focus")      { out = ActionKind::focus;    return true; }
+    if (lower == "scroll")     { out = ActionKind::scroll;   return true; }
+    if (lower == "type" || lower == "typetext")  { out = ActionKind::typeText; return true; }
+    if (lower == "key" || lower == "presskey")   { out = ActionKind::pressKey; return true; }
+    return false;
+}
+
+const char* action_kind_name(ActionKind kind) {
+    switch (kind) {
+    case ActionKind::click:    return "click";
+    case ActionKind::invoke:   return "invoke";
+    case ActionKind::toggle:   return "toggle";
+    case ActionKind::setValue: return "set-value";
+    case ActionKind::expand:   return "expand";
+    case ActionKind::collapse: return "collapse";
+    case ActionKind::select:   return "select";
+    case ActionKind::focus:    return "focus";
+    case ActionKind::scroll:   return "scroll";
+    case ActionKind::typeText: return "type";
+    case ActionKind::pressKey: return "press-key";
+    }
+    return "unknown";
+}
+
+ActionResult perform_action(HWND hwnd, const UiaOptions& options,
+                            const ActionRequest& request) {
+    ActionResult result;
+
+    // Waiting is not an action on a live element: it re-walks until the tree
+    // says what the caller is waiting for, so it is handled before the
+    // resolve-then-act path below.
+    if (request.kind == ActionKind::waitFor || request.kind == ActionKind::waitGone) {
+        if (request.elementRef.empty()) {
+            result.message = "wait requires an element reference";
+            return result;
+        }
+        const auto deadline = std::chrono::steady_clock::now() +
+                              std::chrono::milliseconds((std::max)(0, request.waitTimeoutMs));
+        const bool wantPresent = request.kind == ActionKind::waitFor;
+
+        for (;;) {
+            UiaProvider provider;
+            if (auto tree = provider.build(hwnd, options)) {
+                assign_element_ids(*tree);
+                assign_element_keys(*tree);
+                const Element* found = find_element_by_ref(*tree, request.elementRef);
+
+                bool satisfied = wantPresent ? found != nullptr : found == nullptr;
+                // A property condition narrows "appeared" to "appeared and
+                // settled", which is usually what a caller actually wants.
+                if (satisfied && wantPresent && found && !request.waitProperty.empty()) {
+                    const auto value = get_element_property(*found, request.waitProperty);
+                    satisfied = value.has_value() && *value == request.waitValue;
+                }
+                if (satisfied) {
+                    result.ok = true;
+                    result.method = wantPresent ? "wait-for" : "wait-gone";
+                    if (found) {
+                        result.element = *found;
+                        result.hasElement = true;
+                    }
+                    return result;
+                }
+            }
+
+            if (std::chrono::steady_clock::now() >= deadline)
+                break;
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds((std::max)(10, request.pollIntervalMs)));
+        }
+
+        result.message = wantPresent
+            ? "timed out waiting for '" + request.elementRef + "'" +
+                  (request.waitProperty.empty()
+                       ? std::string()
+                       : " to report " + request.waitProperty + "=" + request.waitValue)
+            : "timed out waiting for '" + request.elementRef + "' to disappear";
+        return result;
+    }
+
+    const bool needsElement = !(request.kind == ActionKind::typeText ||
+                                request.kind == ActionKind::pressKey) ||
+                              !request.elementRef.empty();
+    if (needsElement && request.elementRef.empty()) {
+        result.message = std::string(action_kind_name(request.kind)) +
+                         " requires an element reference";
+        return result;
+    }
+
+    // Resolve the reference against a walk, then re-find the live element by
+    // the RuntimeId that walk reported.
+    Element target;
+    std::vector<int> runtimeId;
+    if (needsElement) {
+        UiaProvider provider;
+        auto tree = provider.build(hwnd, options);
+        if (!tree) {
+            result.message = "could not read the UI Automation tree for this window";
+            return result;
+        }
+        lvt::assign_element_ids(*tree);
+        lvt::assign_element_keys(*tree);
+
+        const Element* found = find_element_by_ref(*tree, request.elementRef);
+        if (!found) {
+            result.message = "element '" + request.elementRef + "' not found";
+            return result;
+        }
+        target = *found;
+
+        const auto it = target.properties.find("RuntimeId");
+        if (it == target.properties.end() || !parse_runtime_id(it->second, runtimeId)) {
+            result.message = "element '" + request.elementRef +
+                             "' has no usable RuntimeId to act on";
+            return result;
+        }
+    }
+
+    std::string method;
+    std::string failure;
+    bool realized = false;
+    const POINT center = element_center(target);
+
+    const HRESULT hr = run_on_mta([&]() -> HRESULT {
+        wil::com_ptr<IUIAutomation> automation;
+        RETURN_IF_FAILED(create_automation(options, &automation));
+
+        wil::com_ptr<IUIAutomationElement> element;
+        if (needsElement) {
+            const HRESULT found = find_by_runtime_id(automation.get(), hwnd, runtimeId, &element);
+            if (FAILED(found)) {
+                failure = "element could not be located in the live tree; it may have "
+                          "changed or disappeared since the walk";
+                RETURN_HR(found);
+            }
+            // Virtualized items have to be made real before anything can touch
+            // them, and this is a no-op on elements that are already real.
+            if (realize_if_virtualized(element.get()))
+                realized = true;
+        }
+
+        switch (request.kind) {
+        case ActionKind::invoke: {
+            const auto attempt = try_invoke(element.get(), method);
+            if (attempt.succeeded())
+                return S_OK;
+            failure = describe_decline(attempt, "Invoke");
+            return attempt.supported ? attempt.hr : E_NOTIMPL;
+        }
+
+        case ActionKind::click: {
+            // Try the quiet routes first. A pattern that exists but fails is
+            // just as much a reason to move on as one that is missing, which is
+            // why both fall through rather than aborting.
+            if (!request.forceSyntheticClick) {
+                const auto invoked = try_invoke(element.get(), method);
+                if (invoked.succeeded())
+                    return S_OK;
+                const auto legacy = try_legacy_default_action(element.get(), method);
+                if (legacy.succeeded())
+                    return S_OK;
+            }
+
+            // Nothing accepted it, so fall back to a real click. This is the
+            // only path that needs the window on top and moves the cursor.
+            if (target.bounds.width <= 0 || target.bounds.height <= 0) {
+                failure = "no pattern would activate this element and it has no "
+                          "on-screen bounds to click";
+                return E_NOTIMPL;
+            }
+            if (!bring_to_foreground(hwnd)) {
+                failure = "no pattern would activate this element, and the window "
+                          "could not be brought to the foreground, so a synthetic "
+                          "click would land on the wrong window";
+                return E_ACCESSDENIED;
+            }
+            if (!send_click(center, request.button, request.amount)) {
+                failure = "SendInput click failed";
+                return E_FAIL;
+            }
+            method = "SendInput";
+            return S_OK;
+        }
+
+        case ActionKind::toggle: {
+            const auto attempt = try_toggle(element.get(), method);
+            if (attempt.succeeded())
+                return S_OK;
+            failure = describe_decline(attempt, "Toggle");
+            return attempt.supported ? attempt.hr : E_NOTIMPL;
+        }
+
+        case ActionKind::setValue: {
+            const auto attempt = try_set_value(element.get(), request.text, method);
+            if (attempt.succeeded())
+                return S_OK;
+
+            // Sliders and spinners carry their value through RangeValue rather
+            // than Value, so a numeric argument gets a second chance there.
+            const auto range = try_set_range_value(element.get(), request.text, method);
+            if (range.succeeded())
+                return S_OK;
+
+            // No writable Value pattern: focus it and retype the contents.
+            if (FAILED(element->SetFocus())) {
+                failure = describe_decline(attempt, "Value") +
+                          ", and the element could not be focused to type into";
+                return E_NOTIMPL;
+            }
+            if (!bring_to_foreground(hwnd)) {
+                failure = describe_decline(attempt, "Value") +
+                          ", and the window could not be brought forward to type into it";
+                return E_ACCESSDENIED;
+            }
+            KeyChord selectAll;
+            if (parse_key_chord("Ctrl+A", selectAll))
+                send_key_chord(selectAll);
+            if (!send_text(request.text)) {
+                failure = "SendInput typing failed";
+                return E_FAIL;
+            }
+            method = "SetFocus+SendInput";
+            return S_OK;
+        }
+
+        case ActionKind::expand:
+        case ActionKind::collapse: {
+            const bool expand = request.kind == ActionKind::expand;
+            const auto attempt = try_expand_collapse(element.get(), expand, method);
+            if (attempt.succeeded())
+                return S_OK;
+            failure = describe_decline(attempt, "ExpandCollapse");
+            return attempt.supported ? attempt.hr : E_NOTIMPL;
+        }
+
+        case ActionKind::select: {
+            const auto attempt = try_select(element.get(), method);
+            if (attempt.succeeded())
+                return S_OK;
+            failure = describe_decline(attempt, "SelectionItem");
+            return attempt.supported ? attempt.hr : E_NOTIMPL;
+        }
+
+        case ActionKind::addToSelection:
+        case ActionKind::removeFromSelection: {
+            const bool add = request.kind == ActionKind::addToSelection;
+            const auto attempt = try_change_selection(element.get(), add, method);
+            if (attempt.succeeded())
+                return S_OK;
+            failure = describe_decline(attempt, "SelectionItem");
+            return attempt.supported ? attempt.hr : E_NOTIMPL;
+        }
+
+        case ActionKind::selectText: {
+            const auto attempt = try_select_text(element.get(), request.text, method);
+            if (attempt.succeeded())
+                return S_OK;
+            if (attempt.supported && attempt.hr == HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
+                failure = "text '" + request.text + "' was not found in this element";
+                return attempt.hr;
+            }
+            failure = describe_decline(attempt, "Text");
+            return attempt.supported ? attempt.hr : E_NOTIMPL;
+        }
+
+        case ActionKind::windowClose:
+        case ActionKind::windowMinimize:
+        case ActionKind::windowMaximize:
+        case ActionKind::windowRestore: {
+            const auto attempt = try_window_action(element.get(), request.kind, method);
+            if (attempt.succeeded())
+                return S_OK;
+            if (attempt.supported && attempt.hr == HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)) {
+                failure = "this window does not allow that state change";
+                return attempt.hr;
+            }
+            failure = describe_decline(attempt, "Window");
+            return attempt.supported ? attempt.hr : E_NOTIMPL;
+        }
+
+        case ActionKind::focus: {
+            const HRESULT hr = element->SetFocus();
+            if (FAILED(hr)) {
+                failure = "the element refused focus";
+                RETURN_HR(hr);
+            }
+            method = "SetFocus";
+            return S_OK;
+        }
+
+        case ActionKind::scroll: {
+            const auto attempt = try_scroll(element.get(), request.direction,
+                                            request.amount, method);
+            if (attempt.succeeded())
+                return S_OK;
+
+            if (!bring_to_foreground(hwnd)) {
+                failure = describe_decline(attempt, "Scroll") +
+                          ", and the window could not be brought forward to send a "
+                          "wheel event";
+                return E_ACCESSDENIED;
+            }
+            const int notch = WHEEL_DELTA * (std::max)(1, request.amount);
+            const bool horizontal = request.direction == "left" || request.direction == "right";
+            const bool negative = request.direction == "down" || request.direction == "left";
+            if (!send_wheel(center, negative ? -notch : notch, horizontal)) {
+                failure = "SendInput wheel failed";
+                return E_FAIL;
+            }
+            method = "SendInput";
+            return S_OK;
+        }
+
+        case ActionKind::typeText:
+        case ActionKind::pressKey: {
+            // Synthetic keyboard input goes to the focused element of the
+            // foreground window, so both prerequisites have to hold.
+            if (element && FAILED(element->SetFocus())) {
+                failure = "could not focus the element to send input to it";
+                return E_NOTIMPL;
+            }
+            if (!bring_to_foreground(hwnd)) {
+                failure = "could not bring the target window to the foreground, so "
+                          "keyboard input would go elsewhere";
+                return E_ACCESSDENIED;
+            }
+            if (request.kind == ActionKind::typeText) {
+                if (!send_text(request.text)) {
+                    failure = "SendInput typing failed";
+                    return E_FAIL;
+                }
+                method = element ? "SetFocus+SendInput" : "SendInput";
+                return S_OK;
+            }
+
+            std::vector<KeyChord> chords;
+            if (!parse_key_chords(request.text, chords)) {
+                failure = "could not parse key chord '" + request.text + "'";
+                return E_INVALIDARG;
+            }
+            for (const auto& chord : chords) {
+                if (!send_key_chord(chord)) {
+                    failure = "SendInput key chord failed";
+                    return E_FAIL;
+                }
+            }
+            method = element ? "SetFocus+SendInput" : "SendInput";
+            return S_OK;
+        }
+        }
+        return E_NOTIMPL;
+    });
+
+    if (FAILED(hr)) {
+        result.message = failure.empty() ? "action failed" : failure;
+        return result;
+    }
+
+    result.ok = true;
+    result.method = realized ? "VirtualizedItem.Realize+" + method : method;
+
+    // Report the element as it is *after* the action, so a caller can see the
+    // effect without a second walk. Re-found by RuntimeId because ids shift
+    // whenever the tree changes, which an action may well have caused.
+    if (needsElement) {
+        UiaProvider provider;
+        if (auto after = provider.build(hwnd, options)) {
+            lvt::assign_element_ids(*after);
+            lvt::assign_element_keys(*after);
+            const auto it = target.properties.find("RuntimeId");
+            if (it != target.properties.end()) {
+                if (const Element* refreshed = find_element_by_ref(*after, "uia:" + it->second)) {
+                    result.element = *refreshed;
+                    result.hasElement = true;
+                }
+            }
+        }
+    }
+    return result;
+}
+
+} // namespace lvt

--- a/src/providers/uia_actions.cpp
+++ b/src/providers/uia_actions.cpp
@@ -59,6 +59,77 @@ HRESULT create_automation(const UiaOptions& options, IUIAutomation** out) {
     return S_OK;
 }
 
+// Compare a RuntimeId SAFEARRAY against the components we are looking for.
+bool runtime_id_matches(SAFEARRAY* array, const std::vector<int>& runtimeId) {
+    if (!array)
+        return false;
+    LONG lower = 0;
+    LONG upper = -1;
+    if (FAILED(SafeArrayGetLBound(array, 1, &lower)) ||
+        FAILED(SafeArrayGetUBound(array, 1, &upper)))
+        return false;
+    if (static_cast<size_t>(upper - lower + 1) != runtimeId.size())
+        return false;
+
+    for (LONG i = lower; i <= upper; ++i) {
+        int component = 0;
+        if (FAILED(SafeArrayGetElement(array, &i, &component)))
+            return false;
+        if (component != runtimeId[static_cast<size_t>(i - lower)])
+            return false;
+    }
+    return true;
+}
+
+// Does this element's live RuntimeId equal the one requested? Used to decide
+// whether the window root is genuinely the element being addressed.
+bool element_has_runtime_id(IUIAutomationElement* element, const std::vector<int>& runtimeId) {
+    wil::unique_variant value;
+    if (FAILED(element->GetCurrentPropertyValue(UIA_RuntimeIdPropertyId, &value)))
+        return false;
+    if (value.vt != (VT_ARRAY | VT_I4))
+        return false;
+    return runtime_id_matches(value.parray, runtimeId);
+}
+
+// The same test against a cached RuntimeId, so a bulk FindAllBuildCache can be
+// scanned without a cross-process call per candidate.
+bool cached_runtime_id_matches(IUIAutomationElement* element, const std::vector<int>& runtimeId) {
+    wil::unique_variant value;
+    if (FAILED(element->GetCachedPropertyValue(UIA_RuntimeIdPropertyId, &value)))
+        return false;
+    if (value.vt != (VT_ARRAY | VT_I4))
+        return false;
+    return runtime_id_matches(value.parray, runtimeId);
+}
+
+// Depth-first search of a materialised cache for the element with this
+// RuntimeId. Purely in-process: the cross-process cost was paid by the
+// BuildUpdatedCache that produced `cachedRoot`.
+wil::com_ptr<IUIAutomationElement> find_in_cached_tree(IUIAutomationElement* node,
+                                                      const std::vector<int>& runtimeId) {
+    if (!node)
+        return {};
+    if (cached_runtime_id_matches(node, runtimeId))
+        return wil::com_ptr<IUIAutomationElement>(node);
+
+    wil::com_ptr<IUIAutomationElementArray> children;
+    if (FAILED(node->GetCachedChildren(&children)) || !children)
+        return {};
+    int count = 0;
+    if (FAILED(children->get_Length(&count)))
+        return {};
+
+    for (int i = 0; i < count; ++i) {
+        wil::com_ptr<IUIAutomationElement> child;
+        if (FAILED(children->GetElement(i, &child)) || !child)
+            continue;
+        if (auto match = find_in_cached_tree(child.get(), runtimeId))
+            return match;
+    }
+    return {};
+}
+
 // Re-find the live element by RuntimeId. The walk produces plain data, so
 // acting on an element means locating it again; RuntimeId is the handle UIA
 // provides for exactly this.
@@ -81,16 +152,50 @@ HRESULT find_by_runtime_id(IUIAutomation* automation, HWND hwnd,
     RETURN_IF_FAILED(automation->CreatePropertyCondition(
         UIA_RuntimeIdPropertyId, condition, &byRuntimeId));
 
+    // FindFirst is the fast path, but it cannot be the only one. Providers are
+    // not required to support RuntimeId in a property condition, and in
+    // practice many do not — against Notepad it matches nothing at all. It is
+    // still tried first because when it does work it is a single round trip.
     wil::com_ptr<IUIAutomationElement> found;
-    RETURN_IF_FAILED(root->FindFirst(TreeScope_Subtree, byRuntimeId.get(), &found));
-    if (!found) {
-        // The root itself is not covered by a Subtree search on some providers.
-        wil::unique_variant rootId;
-        if (SUCCEEDED(root->GetCurrentPropertyValue(UIA_RuntimeIdPropertyId, &rootId)) &&
-            rootId.vt == (VT_ARRAY | VT_I4)) {
-            found = root;
-        }
+    if (FAILED(root->FindFirst(TreeScope_Subtree, byRuntimeId.get(), &found)))
+        found.reset();
+
+    if (!found && element_has_runtime_id(root.get(), runtimeId)) {
+        // TreeScope_Subtree excludes the root on some providers, so the window
+        // element itself has to be checked separately. Comparing the id is what
+        // makes this safe: accepting the root unconditionally would silently
+        // redirect every unresolvable ref at the whole window, so a `close` or
+        // `minimize` aimed at a stale element would act on the application.
+        found = root;
     }
+
+    if (!found) {
+        // Fall back to comparing ids ourselves, using exactly the mechanism the
+        // walk that produced this ref used: BuildUpdatedCache over the raw view,
+        // then a walk of the materialised cache. That equivalence is the point —
+        // FindAll does not descend into child HWNDs hosted by other providers,
+        // so an element whose RuntimeId names a different window (common: a
+        // Notepad TextBlock is `42.<child hwnd>.…` while the root is
+        // `42.<root hwnd>`) is unreachable through it, yet perfectly reachable
+        // here. One BuildUpdatedCache is still a single cross-process trip.
+        wil::com_ptr<IUIAutomationCondition> rawView;
+        RETURN_IF_FAILED(automation->get_RawViewCondition(&rawView));
+
+        wil::com_ptr<IUIAutomationCacheRequest> cache;
+        RETURN_IF_FAILED(automation->CreateCacheRequest(&cache));
+        RETURN_IF_FAILED(cache->put_TreeScope(TreeScope_Subtree));
+        RETURN_IF_FAILED(cache->put_TreeFilter(rawView.get()));
+        // The matched element is acted on afterwards, so it has to stay live
+        // rather than being a detached cache-only copy.
+        RETURN_IF_FAILED(cache->put_AutomationElementMode(AutomationElementMode_Full));
+        RETURN_IF_FAILED(cache->AddProperty(UIA_RuntimeIdPropertyId));
+
+        wil::com_ptr<IUIAutomationElement> cachedRoot;
+        RETURN_IF_FAILED(root->BuildUpdatedCache(cache.get(), &cachedRoot));
+        RETURN_HR_IF_NULL(HRESULT_FROM_WIN32(ERROR_NOT_FOUND), cachedRoot.get());
+        found = find_in_cached_tree(cachedRoot.get(), runtimeId);
+    }
+
     RETURN_HR_IF_NULL(HRESULT_FROM_WIN32(ERROR_NOT_FOUND), found.get());
     *out = found.detach();
     return S_OK;
@@ -101,9 +206,43 @@ POINT element_center(const Element& element) {
                  element.bounds.y + element.bounds.height / 2};
 }
 
-bool has_pattern(IUIAutomationElement* element, PATTERNID pattern) {
-    wil::com_ptr<IUnknown> unknown;
-    return SUCCEEDED(element->GetCurrentPattern(pattern, &unknown)) && unknown;
+// The point to aim synthetic input at, read from the *live* element rather than
+// from the walk that produced the ref.
+//
+// The walk and the action are separate round trips, so anything that scrolls or
+// relayouts in between leaves the walked bounds pointing at whatever now
+// occupies that rectangle. Re-reading here closes that window. The walk's bounds
+// remain the fallback for providers that do not answer the live query.
+//
+// Refuses offscreen elements outright: their bounds are typically far outside
+// the virtual desktop, and clicking such a point would otherwise be clamped
+// onto an unrelated window.
+HRESULT live_element_center(IUIAutomationElement* element, const Element& walked, POINT& out,
+                            std::string& failure) {
+    BOOL offscreen = FALSE;
+    if (SUCCEEDED(element->get_CurrentIsOffscreen(&offscreen)) && offscreen) {
+        failure = "the element is offscreen, so there is nothing on screen to click; "
+                  "scroll it into view first";
+        return HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
+    }
+
+    RECT live{};
+    if (SUCCEEDED(element->get_CurrentBoundingRectangle(&live)) &&
+        live.right > live.left && live.bottom > live.top) {
+        out = POINT{live.left + (live.right - live.left) / 2,
+                    live.top + (live.bottom - live.top) / 2};
+    } else if (walked.bounds.width > 0 && walked.bounds.height > 0) {
+        out = element_center(walked);
+    } else {
+        failure = "the element has no on-screen bounds to target";
+        return HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
+    }
+
+    if (!point_is_on_screen(out)) {
+        failure = "the element's on-screen position is not on any monitor";
+        return HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
+    }
+    return S_OK;
 }
 
 std::wstring widen(const std::string& text) {
@@ -254,13 +393,18 @@ PatternAttempt try_scroll(IUIAutomationElement* element, const std::string& dire
 // A virtualized item does not exist as a real element until it is realized, so
 // nothing can be done to it. Realizing first is transparent and cheap: an
 // already-real element simply does not expose the pattern.
+// Make a virtualized item real so it can be acted on. Returns true only when
+// Realize() actually succeeded: the caller reports this in `method`, and
+// claiming a realize that failed would misattribute how the action was carried
+// out.
 bool realize_if_virtualized(IUIAutomationElement* element) {
     wil::com_ptr<IUIAutomationVirtualizedItemPattern> virtualized;
     if (FAILED(element->GetCurrentPatternAs(UIA_VirtualizedItemPatternId,
                                             IID_PPV_ARGS(&virtualized))) || !virtualized)
         return false;
-    LOG_IF_FAILED(virtualized->Realize());
-    return true;
+    const HRESULT hr = virtualized->Realize();
+    LOG_IF_FAILED(hr);
+    return SUCCEEDED(hr);
 }
 
 PatternAttempt try_set_range_value(IUIAutomationElement* element, const std::string& text,
@@ -379,38 +523,59 @@ std::string describe_decline(const PatternAttempt& attempt, const char* patternN
 
 } // namespace
 
+// The one place an ActionKind's textual name is defined. `parse_action_kind`
+// and `action_kind_name` are both generated from this, so a new kind cannot end
+// up parseable but nameless (or vice versa) — the earlier hand-written pair had
+// drifted to the point that nine kinds reported themselves as "unknown".
+//
+// The first spelling is the canonical one, the rest are accepted aliases.
+struct ActionKindNames {
+    ActionKind kind;
+    const char* canonical;
+    const char* alias;  // nullptr when there is none
+};
+
+constexpr ActionKindNames kActionKindNames[] = {
+    {ActionKind::click,               "click",                 nullptr},
+    {ActionKind::invoke,              "invoke",                nullptr},
+    {ActionKind::toggle,              "toggle",                nullptr},
+    {ActionKind::setValue,            "set-value",             "setvalue"},
+    {ActionKind::expand,              "expand",                nullptr},
+    {ActionKind::collapse,            "collapse",              nullptr},
+    {ActionKind::select,              "select",                nullptr},
+    {ActionKind::addToSelection,      "add-to-selection",      "addtoselection"},
+    {ActionKind::removeFromSelection, "remove-from-selection", "removefromselection"},
+    {ActionKind::selectText,          "select-text",           "selecttext"},
+    {ActionKind::focus,               "focus",                 nullptr},
+    {ActionKind::scroll,              "scroll",                nullptr},
+    {ActionKind::typeText,            "type",                  "typetext"},
+    {ActionKind::pressKey,            "press-key",             "presskey"},
+    {ActionKind::windowClose,         "close",                 "windowclose"},
+    {ActionKind::windowMinimize,      "minimize",              "windowminimize"},
+    {ActionKind::windowMaximize,      "maximize",              "windowmaximize"},
+    {ActionKind::windowRestore,       "restore",               "windowrestore"},
+    {ActionKind::waitFor,             "wait-for",              "waitfor"},
+    {ActionKind::waitGone,            "wait-gone",             "waitgone"},
+};
+
 bool parse_action_kind(const std::string& name, ActionKind& out) {
     std::string lower = name;
     std::transform(lower.begin(), lower.end(), lower.begin(),
                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
 
-    if (lower == "click")      { out = ActionKind::click;    return true; }
-    if (lower == "invoke")     { out = ActionKind::invoke;   return true; }
-    if (lower == "toggle")     { out = ActionKind::toggle;   return true; }
-    if (lower == "setvalue" || lower == "set-value") { out = ActionKind::setValue; return true; }
-    if (lower == "expand")     { out = ActionKind::expand;   return true; }
-    if (lower == "collapse")   { out = ActionKind::collapse; return true; }
-    if (lower == "select")     { out = ActionKind::select;   return true; }
-    if (lower == "focus")      { out = ActionKind::focus;    return true; }
-    if (lower == "scroll")     { out = ActionKind::scroll;   return true; }
-    if (lower == "type" || lower == "typetext")  { out = ActionKind::typeText; return true; }
-    if (lower == "key" || lower == "presskey")   { out = ActionKind::pressKey; return true; }
+    for (const auto& entry : kActionKindNames) {
+        if (lower == entry.canonical || (entry.alias && lower == entry.alias)) {
+            out = entry.kind;
+            return true;
+        }
+    }
     return false;
 }
 
 const char* action_kind_name(ActionKind kind) {
-    switch (kind) {
-    case ActionKind::click:    return "click";
-    case ActionKind::invoke:   return "invoke";
-    case ActionKind::toggle:   return "toggle";
-    case ActionKind::setValue: return "set-value";
-    case ActionKind::expand:   return "expand";
-    case ActionKind::collapse: return "collapse";
-    case ActionKind::select:   return "select";
-    case ActionKind::focus:    return "focus";
-    case ActionKind::scroll:   return "scroll";
-    case ActionKind::typeText: return "type";
-    case ActionKind::pressKey: return "press-key";
+    for (const auto& entry : kActionKindNames) {
+        if (entry.kind == kind)
+            return entry.canonical;
     }
     return "unknown";
 }
@@ -432,6 +597,22 @@ ActionResult perform_action(HWND hwnd, const UiaOptions& options,
         const bool wantPresent = request.kind == ActionKind::waitFor;
 
         for (;;) {
+            // A destroyed window is a definite answer, not a failed read: an
+            // element inside a window that no longer exists is unambiguously
+            // gone. Without this the natural `close` then `wait-gone` pairing
+            // polls until it times out, reporting failure for the exact
+            // outcome it was waiting for.
+            if (!IsWindow(hwnd)) {
+                if (!wantPresent) {
+                    result.ok = true;
+                    result.method = "wait-gone";
+                    return result;
+                }
+                result.message = "the window closed while waiting for '" +
+                                 request.elementRef + "'";
+                return result;
+            }
+
             UiaProvider provider;
             if (auto tree = provider.build(hwnd, options)) {
                 assign_element_ids(*tree);
@@ -512,7 +693,6 @@ ActionResult perform_action(HWND hwnd, const UiaOptions& options,
     std::string method;
     std::string failure;
     bool realized = false;
-    const POINT center = element_center(target);
 
     const HRESULT hr = run_on_mta([&]() -> HRESULT {
         wil::com_ptr<IUIAutomation> automation;
@@ -556,11 +736,8 @@ ActionResult perform_action(HWND hwnd, const UiaOptions& options,
 
             // Nothing accepted it, so fall back to a real click. This is the
             // only path that needs the window on top and moves the cursor.
-            if (target.bounds.width <= 0 || target.bounds.height <= 0) {
-                failure = "no pattern would activate this element and it has no "
-                          "on-screen bounds to click";
-                return E_NOTIMPL;
-            }
+            POINT center{};
+            RETURN_IF_FAILED(live_element_center(element.get(), target, center, failure));
             if (!bring_to_foreground(hwnd)) {
                 failure = "no pattern would activate this element, and the window "
                           "could not be brought to the foreground, so a synthetic "
@@ -696,7 +873,9 @@ ActionResult perform_action(HWND hwnd, const UiaOptions& options,
             const int notch = WHEEL_DELTA * (std::max)(1, request.amount);
             const bool horizontal = request.direction == "left" || request.direction == "right";
             const bool negative = request.direction == "down" || request.direction == "left";
-            if (!send_wheel(center, negative ? -notch : notch, horizontal)) {
+            POINT wheelPoint{};
+            RETURN_IF_FAILED(live_element_center(element.get(), target, wheelPoint, failure));
+            if (!send_wheel(wheelPoint, negative ? -notch : notch, horizontal)) {
                 failure = "SendInput wheel failed";
                 return E_FAIL;
             }

--- a/src/providers/uia_actions.h
+++ b/src/providers/uia_actions.h
@@ -1,0 +1,86 @@
+#pragma once
+#include "../element.h"
+#include "uia_props.h"
+#include "uia_provider.h"
+
+#include <string>
+#include <vector>
+#include <Windows.h>
+
+namespace lvt {
+
+enum class ActionKind {
+    click,        // Invoke, else LegacyIAccessible default action, else a real click
+    invoke,       // InvokePattern only
+    toggle,       // TogglePattern
+    setValue,     // ValuePattern, else RangeValue for numbers, else focus + type
+    expand,
+    collapse,
+    select,       // SelectionItemPattern::Select (replaces the selection)
+    addToSelection,
+    removeFromSelection,
+    selectText,   // TextPattern: find a substring and select that range
+    focus,
+    scroll,
+    typeText,     // send text to the focused element, optionally focusing first
+    pressKey,     // key chord(s), optionally focusing an element first
+    windowClose,
+    windowMinimize,
+    windowMaximize,
+    windowRestore,
+    waitFor,      // block until an element appears, optionally with a property value
+    waitGone,     // block until an element disappears
+};
+
+struct ActionRequest {
+    ActionKind kind = ActionKind::click;
+
+    // Element reference: "eN", a durable key, or "uia:<RuntimeId>". May be empty
+    // for typeText/pressKey, which then act on whatever already has focus.
+    std::string elementRef;
+
+    std::string text;       // setValue / typeText / pressKey / selectText
+    std::string direction;  // scroll: up, down, left, right
+    int amount = 1;         // scroll notches, or click count
+    int button = 0;         // 0 left, 1 right, 2 middle
+    // Right-click and double-click have no pattern equivalent — Invoke is just
+    // "activate" — so they must go straight to synthetic input rather than
+    // silently succeeding via a pattern that does something else.
+    bool forceSyntheticClick = false;
+
+    // waitFor / waitGone. When waitProperty is set, waitFor blocks until the
+    // element reports that value rather than merely existing.
+    std::string waitProperty;
+    std::string waitValue;
+    int waitTimeoutMs = 5000;
+    int pollIntervalMs = 100;
+};
+
+struct ActionResult {
+    bool ok = false;
+    // How the action was actually carried out — "InvokePattern",
+    // "ValuePattern", "SendInput", ... Callers surface this because a pattern
+    // and a synthetic click are meaningfully different outcomes.
+    std::string method;
+    std::string message;
+    // The element acted on, after the action, so a caller can see the result
+    // without a second walk.
+    Element element;
+    bool hasElement = false;
+};
+
+// Resolve the reference against a fresh UIA walk of the target and perform the
+// action. Everything happens on the provider's MTA thread.
+//
+// Pattern-based paths are preferred throughout: they do not steal focus, do not
+// move the cursor, and work when the window is not on top. SendInput is the
+// fallback for elements that expose no suitable pattern, and it requires
+// bringing the window forward.
+ActionResult perform_action(HWND hwnd, const UiaOptions& options,
+                            const ActionRequest& request);
+
+// Parse an action name as accepted on the command line.
+bool parse_action_kind(const std::string& name, ActionKind& out);
+const char* action_kind_name(ActionKind kind);
+
+} // namespace lvt

--- a/tests/apps/WinUI3Sample/MainWindow.xaml
+++ b/tests/apps/WinUI3Sample/MainWindow.xaml
@@ -4,8 +4,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="LVT WinUI3 Sample">
 
-    <Grid x:Name="RootGrid" Padding="24" RowSpacing="12" Width="420" Height="260">
+    <Grid x:Name="RootGrid" Padding="24" RowSpacing="12" Width="420" Height="300">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -14,7 +15,10 @@
 
         <TextBlock x:Name="HeaderText" Text="LVT WinUI3 Sample" FontSize="24" />
         <TextBox x:Name="InputBox" Grid.Row="1" Header="Sample input" Text="Durable key text" />
-        <Button x:Name="PrimaryButton" Grid.Row="2" Content="Primary action" />
+        <Button x:Name="PrimaryButton" Grid.Row="2" Content="Primary action" Click="OnPrimaryClick" />
         <CheckBox x:Name="ReadyCheckBox" Grid.Row="3" Content="Ready" IsChecked="True" />
+        <!-- Gives interaction tests something observable to assert against:
+             a click has no effect a UIA walk can see unless it changes state. -->
+        <TextBlock x:Name="StatusText" Grid.Row="4" Text="clicks:0" />
     </Grid>
 </Window>

--- a/tests/apps/WinUI3Sample/MainWindow.xaml
+++ b/tests/apps/WinUI3Sample/MainWindow.xaml
@@ -4,13 +4,16 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="LVT WinUI3 Sample">
 
-    <Grid x:Name="RootGrid" Padding="24" RowSpacing="12" Width="420" Height="300">
+    <Grid x:Name="RootGrid" Padding="24" RowSpacing="12" Width="460" Height="620">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
         <TextBlock x:Name="HeaderText" Text="LVT WinUI3 Sample" FontSize="24" />
@@ -20,5 +23,17 @@
         <!-- Gives interaction tests something observable to assert against:
              a click has no effect a UIA walk can see unless it changes state. -->
         <TextBlock x:Name="StatusText" Grid.Row="4" Text="clicks:0" />
+
+        <!-- The controls below exist so the interaction verbs have something to
+             act on: a slider for RangeValue, a combo box for ExpandCollapse and
+             Selection, and a long virtualized list for Scroll, SelectionItem
+             and VirtualizedItem.Realize. -->
+        <Slider x:Name="LevelSlider" Grid.Row="5" Minimum="0" Maximum="100" Value="25" />
+        <ComboBox x:Name="ChoiceCombo" Grid.Row="6" SelectedIndex="0" Width="200">
+            <ComboBoxItem Content="Alpha" />
+            <ComboBoxItem Content="Beta" />
+            <ComboBoxItem Content="Gamma" />
+        </ComboBox>
+        <ListView x:Name="ItemsList" Grid.Row="7" Height="220" SelectionMode="Multiple" />
     </Grid>
 </Window>

--- a/tests/apps/WinUI3Sample/MainWindow.xaml.cs
+++ b/tests/apps/WinUI3Sample/MainWindow.xaml.cs
@@ -4,9 +4,17 @@ namespace WinUI3Sample;
 
 public sealed partial class MainWindow : Window
 {
+    private int _clicks;
+
     public MainWindow()
     {
         InitializeComponent();
         Title = "LVT WinUI3 Sample";
+    }
+
+    // Interaction tests need an effect a UIA walk can observe.
+    private void OnPrimaryClick(object sender, RoutedEventArgs e)
+    {
+        StatusText.Text = $"clicks:{++_clicks}";
     }
 }

--- a/tests/apps/WinUI3Sample/MainWindow.xaml.cs
+++ b/tests/apps/WinUI3Sample/MainWindow.xaml.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Microsoft.UI.Xaml;
 
 namespace WinUI3Sample;
@@ -10,6 +11,13 @@ public sealed partial class MainWindow : Window
     {
         InitializeComponent();
         Title = "LVT WinUI3 Sample";
+
+        // Long enough that the list virtualizes, so VirtualizedItem.Realize and
+        // scrolling have something real to act on.
+        var items = new List<string>();
+        for (int i = 0; i < 200; i++)
+            items.Add($"Item {i:D3}");
+        ItemsList.ItemsSource = items;
     }
 
     // Interaction tests need an effect a UIA walk can observe.

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -2697,3 +2697,271 @@ TEST_F(WinUI3SampleFixture, ActionsReportFailureForUnknownElements) {
     EXPECT_FALSE(result.value("ok", true));
     EXPECT_FALSE(result.value("error", "").empty());
 }
+
+TEST_F(WinUI3SampleFixture, SetValueFallsBackToRangeValueForNumericControls) {
+    SkipIfNotReady();
+    auto lvt = get_lvt_path();
+
+    // A slider carries its value through RangeValue, not Value, so set-value
+    // has to try both before giving up and typing.
+    auto slider = uia_element(lvt, get_pid_arg(), "LevelSlider");
+    ASSERT_FALSE(slider.is_null()) << "sample app has no LevelSlider";
+    const auto ref = "uia:" + uia_prop(slider, "RuntimeId");
+
+    auto result = run_action_json(lvt, get_pid_arg() + " set-value " + ref + " 75");
+    EXPECT_TRUE(result.value("ok", false)) << result.dump(2);
+    EXPECT_EQ(result.value("method", ""), "RangeValuePattern");
+
+    auto after = uia_element(lvt, get_pid_arg(), "LevelSlider");
+    ASSERT_FALSE(after.is_null());
+    EXPECT_EQ(uia_prop(after, "RangeValue.Value"), "75");
+}
+
+TEST_F(WinUI3SampleFixture, ExpandAndCollapseDriveTheExpandCollapsePattern) {
+    SkipIfNotReady();
+    auto lvt = get_lvt_path();
+
+    auto combo = uia_element(lvt, get_pid_arg(), "ChoiceCombo");
+    ASSERT_FALSE(combo.is_null()) << "sample app has no ChoiceCombo";
+
+    // Deliberately the durable key, not uia:<RuntimeId>. Expanding a combo box
+    // reparents it into a popup, which changes both its eN id and the
+    // HWND-derived part of its RuntimeId; only the durable key survives. That
+    // is the whole reason durable keys exist.
+    const auto ref = cmd_escape_arg(combo.value("key", ""));
+    ASSERT_FALSE(ref.empty());
+
+    auto expanded = run_action_json(lvt, get_pid_arg() + " --uia expand " + ref);
+    EXPECT_TRUE(expanded.value("ok", false)) << expanded.dump(2);
+    EXPECT_EQ(expanded.value("method", ""), "ExpandCollapsePattern");
+    EXPECT_EQ(uia_prop(uia_element(lvt, get_pid_arg(), "ChoiceCombo"),
+                       "ExpandCollapse.State"), "Expanded");
+
+    auto collapsed = run_action_json(lvt, get_pid_arg() + " --uia collapse " + ref);
+    EXPECT_TRUE(collapsed.value("ok", false)) << collapsed.dump(2);
+    EXPECT_EQ(uia_prop(uia_element(lvt, get_pid_arg(), "ChoiceCombo"),
+                       "ExpandCollapse.State"), "Collapsed");
+}
+
+TEST_F(WinUI3SampleFixture, DurableKeysOutliveReferencesThatStructureBreaks) {
+    SkipIfNotReady();
+    auto lvt = get_lvt_path();
+
+    // Pins the identity guidance the docs give, because it is not obvious.
+    // Expanding a combo box reparents it into a popup. A durable key captured
+    // beforehand still resolves to something actionable afterwards; the
+    // RuntimeId captured at the same moment does not, because its host-window
+    // component changed.
+    auto before = uia_element(lvt, get_pid_arg(), "ChoiceCombo");
+    ASSERT_FALSE(before.is_null());
+    const auto key = before.value("key", "");
+    const auto runtimeRef = "uia:" + uia_prop(before, "RuntimeId");
+    ASSERT_FALSE(key.empty());
+
+    auto expanded = run_action_json(lvt,
+        get_pid_arg() + " --uia expand " + cmd_escape_arg(key));
+    ASSERT_TRUE(expanded.value("ok", false)) << expanded.dump(2);
+
+    // The pre-expand RuntimeId is now stale.
+    auto viaRuntimeId = run_action_json(lvt,
+        get_pid_arg() + " --uia collapse " + runtimeRef);
+    EXPECT_FALSE(viaRuntimeId.value("ok", true))
+        << "if RuntimeId survived reparenting here, the docs should stop warning about it";
+
+    // The durable key captured before the change still works.
+    auto viaKey = run_action_json(lvt,
+        get_pid_arg() + " --uia collapse " + cmd_escape_arg(key));
+    EXPECT_TRUE(viaKey.value("ok", false)) << viaKey.dump(2);
+    EXPECT_EQ(uia_prop(uia_element(lvt, get_pid_arg(), "ChoiceCombo"),
+                       "ExpandCollapse.State"), "Collapsed");
+}
+
+TEST_F(WinUI3SampleFixture, ScrollDrivesTheScrollPattern) {
+    SkipIfNotReady();
+    auto lvt = get_lvt_path();
+
+    auto list = uia_element(lvt, get_pid_arg(), "ItemsList");
+    ASSERT_FALSE(list.is_null()) << "sample app has no ItemsList";
+    const auto ref = "uia:" + uia_prop(list, "RuntimeId");
+    const auto before = uia_prop(list, "Scroll.VerticalPercent");
+
+    auto result = run_action_json(lvt, get_pid_arg() + " scroll " + ref + " down");
+    EXPECT_TRUE(result.value("ok", false)) << result.dump(2);
+    // A scrollable list must use the pattern, not the wheel: the wheel needs
+    // the window in front and lands wherever the cursor is.
+    EXPECT_EQ(result.value("method", ""), "ScrollPattern");
+
+    auto after = uia_element(lvt, get_pid_arg(), "ItemsList");
+    ASSERT_FALSE(after.is_null());
+    EXPECT_NE(uia_prop(after, "Scroll.VerticalPercent"), before)
+        << "scroll reported success but the list did not move";
+}
+
+TEST_F(WinUI3SampleFixture, SelectionVerbsRealizeVirtualizedItems) {
+    SkipIfNotReady();
+    auto lvt = get_lvt_path();
+
+    // A long list virtualizes, so its items are placeholders until realized.
+    // This is the case that separates working on a toy UI from a real one.
+    auto tree = json::parse(run_command(make_cmd(lvt, get_pid_arg() + " dump --uia")),
+                            nullptr, false);
+    ASSERT_FALSE(tree.is_discarded());
+
+    std::vector<const json*> stack{&tree["root"]};
+    std::vector<std::string> virtualizedRefs;
+    while (!stack.empty()) {
+        const json* node = stack.back();
+        stack.pop_back();
+        if (node->value("type", "") == "ListItem" &&
+            uia_prop(*node, "SupportedPatterns").find("VirtualizedItem") != std::string::npos) {
+            virtualizedRefs.push_back("uia:" + uia_prop(*node, "RuntimeId"));
+        }
+        if (node->contains("children")) {
+            for (const auto& child : (*node)["children"])
+                stack.push_back(&child);
+        }
+    }
+    ASSERT_GE(virtualizedRefs.size(), 2u) << "expected a virtualized list to act on";
+
+    auto selected = run_action_json(lvt, get_pid_arg() + " select " + virtualizedRefs[0]);
+    EXPECT_TRUE(selected.value("ok", false)) << selected.dump(2);
+    // The method must admit the realize step happened.
+    EXPECT_NE(selected.value("method", "").find("VirtualizedItem.Realize"), std::string::npos)
+        << selected.dump(2);
+    EXPECT_NE(selected.value("method", "").find("SelectionItemPattern"), std::string::npos);
+
+    auto added = run_action_json(lvt,
+        get_pid_arg() + " add-to-selection " + virtualizedRefs[1]);
+    EXPECT_TRUE(added.value("ok", false)) << added.dump(2);
+    EXPECT_NE(added.value("method", "").find("AddToSelection"), std::string::npos);
+
+    auto removed = run_action_json(lvt,
+        get_pid_arg() + " remove-from-selection " + virtualizedRefs[1]);
+    EXPECT_TRUE(removed.value("ok", false)) << removed.dump(2);
+}
+
+TEST_F(WinUI3SampleFixture, FocusAndSelectTextActOnTheTextBox) {
+    SkipIfNotReady();
+    auto lvt = get_lvt_path();
+
+    auto box = uia_element(lvt, get_pid_arg(), "InputBox");
+    ASSERT_FALSE(box.is_null());
+    const auto ref = "uia:" + uia_prop(box, "RuntimeId");
+
+    auto focused = run_action_json(lvt, get_pid_arg() + " focus " + ref);
+    EXPECT_TRUE(focused.value("ok", false)) << focused.dump(2);
+    EXPECT_EQ(focused.value("method", ""), "SetFocus");
+    EXPECT_EQ(uia_prop(uia_element(lvt, get_pid_arg(), "InputBox"), "HasKeyboardFocus"),
+              "true");
+
+    // With no argument, select-text selects everything.
+    auto selectedAll = run_action_json(lvt, get_pid_arg() + " select-text " + ref);
+    EXPECT_TRUE(selectedAll.value("ok", false)) << selectedAll.dump(2);
+    EXPECT_NE(selectedAll.value("method", "").find("TextPattern"), std::string::npos);
+}
+
+TEST_F(WinUI3SampleFixture, WaitGoneSucceedsForAnElementThatNeverExisted) {
+    SkipIfNotReady();
+    auto lvt = get_lvt_path();
+
+    // An absent element is already "gone", so this must return rather than
+    // burn the whole timeout.
+    const auto start = GetTickCount64();
+    auto result = run_action_json(lvt,
+        get_pid_arg() + " wait-gone uia:99.99.99 --wait-timeout 5000");
+    const auto elapsed = GetTickCount64() - start;
+
+    EXPECT_TRUE(result.value("ok", false)) << result.dump(2);
+    EXPECT_LT(elapsed, 4000u) << "wait-gone should return as soon as the element is absent";
+}
+
+// --- Verb parsing ---
+// The CLI restructure moved every mode from a flag to a positional verb. That
+// parsing has no unit-test seam (it lives in main.cpp), so it is covered here
+// through the binary, which is also how users hit it.
+
+TEST_F(NotepadFixture, DumpIsTheDefaultVerb) {
+    auto lvt = get_lvt_path();
+    // Omitting the verb has to keep working, or every existing invocation and
+    // every published example breaks.
+    auto implied = run_command(make_cmd(lvt, get_pid_arg()));
+    auto explicitDump = run_command(make_cmd(lvt, get_pid_arg() + " dump"));
+
+    auto a = json::parse(implied, nullptr, false);
+    auto b = json::parse(explicitDump, nullptr, false);
+    ASSERT_FALSE(a.is_discarded()) << "implied dump produced no JSON";
+    ASSERT_FALSE(b.is_discarded()) << "explicit dump produced no JSON";
+    EXPECT_TRUE(a.contains("root"));
+    EXPECT_TRUE(b.contains("root"));
+}
+
+TEST_F(NotepadFixture, VerbCanFollowOptions) {
+    // Options are order-independent, so the verb must be found wherever it sits.
+    auto lvt = get_lvt_path();
+    auto before = run_command(make_cmd(lvt, "frameworks " + get_pid_arg()));
+    auto after = run_command(make_cmd(lvt, get_pid_arg() + " frameworks"));
+    EXPECT_FALSE(before.empty());
+    EXPECT_EQ(before, after);
+}
+
+TEST_F(NotepadFixture, LegacyFlagsReportTheirReplacement) {
+    auto lvt = get_lvt_path();
+    // "unknown argument" would be unhelpful here: the shape of the command
+    // changed, not the spelling of a flag.
+    struct Case { const char* flag; const char* expect; };
+    const Case cases[] = {
+        {"--dump", "dump"},
+        {"--frameworks", "frameworks"},
+        {"--watch", "watch"},
+        {"--query", "query"},
+        {"--screenshot", "screenshot"},
+    };
+    for (const auto& c : cases) {
+        auto output = run_command(make_cmd(lvt, get_pid_arg() + " " + c.flag) + " 2>&1");
+        EXPECT_NE(output.find("is now"), std::string::npos)
+            << c.flag << " should report its replacement, got:\n" << output;
+        EXPECT_NE(output.find(c.expect), std::string::npos)
+            << c.flag << " should name the '" << c.expect << "' verb";
+    }
+}
+
+TEST_F(NotepadFixture, UnknownVerbAndBadArityAreRejected) {
+    auto lvt = get_lvt_path();
+
+    auto unknown = run_command(make_cmd(lvt, get_pid_arg() + " frobnicate") + " 2>&1");
+    EXPECT_NE(unknown.find("unknown verb"), std::string::npos) << unknown;
+
+    // set-value needs two arguments; one must not be silently accepted.
+    auto tooFew = run_command(make_cmd(lvt, get_pid_arg() + " set-value e0") + " 2>&1");
+    EXPECT_NE(tooFew.find("usage"), std::string::npos) << tooFew;
+
+    // query takes at most two.
+    auto tooMany = run_command(make_cmd(lvt, get_pid_arg() + " query e0 type extra") + " 2>&1");
+    EXPECT_NE(tooMany.find("usage"), std::string::npos) << tooMany;
+}
+
+TEST_F(NotepadFixture, ScreenshotVerbDefaultsAndHonoursOutput) {
+    auto lvt = get_lvt_path();
+    auto tmpFile = fs::path(lvt).parent_path() / "lvt_verb_shot.png";
+    fs::remove(tmpFile);
+
+    run_command(make_cmd(lvt, get_pid_arg() + " screenshot --output " + tmpFile.string()));
+    EXPECT_TRUE(fs::exists(tmpFile)) << "--output should name the PNG for the screenshot verb";
+    fs::remove(tmpFile);
+}
+
+TEST_F(WinUI3SampleFixture, UiaReferenceImpliesTheUiaTree) {
+    SkipIfNotReady();
+    auto lvt = get_lvt_path();
+
+    auto button = uia_element(lvt, get_pid_arg(), "PrimaryButton");
+    ASSERT_FALSE(button.is_null());
+    const auto runtimeId = uia_prop(button, "RuntimeId");
+    ASSERT_FALSE(runtimeId.empty());
+
+    // A uia: reference cannot resolve against the visual tree, so asking for
+    // one without --uia would otherwise fail confusingly.
+    auto queried = trim_crlf(run_command(make_cmd(
+        lvt, get_pid_arg() + " query uia:" + runtimeId + " AutomationId")));
+    EXPECT_EQ(queried, "PrimaryButton");
+}

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -71,6 +71,17 @@ static std::string trim_crlf(const std::string& value) {
     return value.substr(0, end + 1);
 }
 
+// Read a repository file for tests that assert on documentation. Line endings
+// are normalised so a checkout with autocrlf does not look like a difference.
+static std::string read_text_file(const std::string& path) {
+    std::ifstream file(path, std::ios::binary);
+    if (!file)
+        return {};
+    std::string text((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    text.erase(std::remove(text.begin(), text.end(), '\r'), text.end());
+    return text;
+}
+
 // Launch a dedicated Notepad instance for testing
 class NotepadFixture : public ::testing::Test {
 protected:
@@ -2608,14 +2619,41 @@ TEST_F(WinUI3SampleFixture, ActionResultReportsHowItWasPerformed) {
     ASSERT_FALSE(button.is_null());
     const auto ref = "uia:" + uia_prop(button, "RuntimeId");
 
+    const auto readStatus = [&] {
+        auto status = uia_element(lvt, get_pid_arg(), "StatusText");
+        return status.is_null() ? std::string() : status.value("text", "");
+    };
+
+    const auto beforePattern = readStatus();
+    ASSERT_FALSE(beforePattern.empty());
+
     auto viaPattern = run_action_json(lvt, get_pid_arg() + " click " + ref);
     EXPECT_EQ(viaPattern.value("method", ""), "InvokePattern");
+    EXPECT_NE(readStatus(), beforePattern) << "the pattern click did not reach the app";
 
     // double-click has no pattern equivalent, so it must say it used SendInput
     // rather than quietly invoking once and claiming success.
+    const auto beforeInput = readStatus();
     auto viaInput = run_action_json(lvt, get_pid_arg() + " double-click " + ref);
+
+    if (!viaInput.value("ok", false) &&
+        viaInput.value("error", "").find("foreground") != std::string::npos) {
+        // SetForegroundWindow is advisory: the shell refuses it when another
+        // process owns the foreground, which on a shared machine can be
+        // anything. Refusing is the correct behaviour — a synthetic click that
+        // proceeded anyway would land on the wrong window — so this is an
+        // environment limitation rather than a defect.
+        GTEST_SKIP() << "another window held the foreground, so synthetic input was "
+                        "correctly refused: " << viaInput.dump(2);
+    }
+
     EXPECT_TRUE(viaInput.value("ok", false)) << viaInput.dump(2);
     EXPECT_EQ(viaInput.value("method", ""), "SendInput");
+    // The label alone proves nothing: assert the app actually saw the click.
+    // This is the only synthetic-input path in the suite, and so the one most
+    // worth verifying by effect rather than by what it claims to have done.
+    EXPECT_NE(readStatus(), beforeInput)
+        << "the synthetic click reported success but the app did not react";
 }
 
 TEST_F(WinUI3SampleFixture, InvokeRefusesElementsWithoutThePattern) {
@@ -2860,6 +2898,273 @@ TEST_F(WinUI3SampleFixture, FocusAndSelectTextActOnTheTextBox) {
     EXPECT_NE(selectedAll.value("method", "").find("TextPattern"), std::string::npos);
 }
 
+// --- Regressions from the PR review ---
+// Each of these pins a bug that shipped and was caught in review, so the test
+// names describe the wrong behaviour they prevent rather than the API surface.
+
+TEST_F(NotepadFixture, ActionOnANonWindowElementDoesNotActOnTheWindow) {
+    auto lvt = get_lvt_path();
+
+    // Re-finding an element used to fall back to the window root whenever the
+    // lookup missed, without checking the id matched. `minimize` aimed at a
+    // TextBlock therefore minimized the whole application and reported success.
+    // A raw-view element is the case that triggered it: its RuntimeId names a
+    // child HWND, which is exactly what the lookup could not reach.
+    auto tree = json::parse(
+        run_command(make_cmd(lvt, get_pid_arg() + " dump --uia --uia-view raw")), nullptr, false);
+    ASSERT_FALSE(tree.is_discarded()) << "raw UIA dump produced no JSON";
+
+    std::vector<const json*> all;
+    collect_json_elements(tree["root"], all);
+    const json* target = nullptr;
+    const auto rootId = uia_prop(tree["root"], "RuntimeId");
+    for (const auto* element : all) {
+        const auto rid = uia_prop(*element, "RuntimeId");
+        if (rid.empty() || rid == rootId)
+            continue;
+        // It has to be an element FindFirst cannot resolve, or the buggy
+        // fallback is never reached and the test proves nothing. Raw-view-only
+        // elements are exactly that case, and a Text element additionally
+        // guarantees the Window pattern is absent, so a correct implementation
+        // must refuse.
+        if (uia_prop(*element, "IsControlElement") != "false")
+            continue;
+        if (element->value("type", "") != "Text")
+            continue;
+        target = element;
+        break;
+    }
+    if (!target)
+        GTEST_SKIP() << "no raw-view-only Text element in this Notepad build to test with";
+
+    const auto ref = "uia:" + uia_prop(*target, "RuntimeId");
+    auto result = run_action_json(lvt, get_pid_arg() + " minimize " + ref + " --uia-view raw");
+
+    EXPECT_FALSE(result.value("ok", true))
+        << "minimizing a Text element must fail, not minimize the window: " << result.dump(2);
+    // The specific message matters: it proves the element was found and the
+    // pattern was checked, rather than the lookup silently redirecting to the
+    // window (which would have succeeded).
+    EXPECT_NE(result.value("error", "").find("does not support"), std::string::npos)
+        << result.dump(2);
+    EXPECT_FALSE(IsIconic(s_hwnd)) << "the window was minimized by an action aimed elsewhere";
+}
+
+TEST_F(NotepadFixture, RawViewOnlyElementsCanStillBeResolvedForActions) {
+    auto lvt = get_lvt_path();
+
+    // The counterpart to the test above: refusing must come from the pattern
+    // check, not from the element being unreachable. If re-finding regressed to
+    // control-view-only lookup this would report "could not be located".
+    auto tree = json::parse(
+        run_command(make_cmd(lvt, get_pid_arg() + " dump --uia --uia-view raw")), nullptr, false);
+    ASSERT_FALSE(tree.is_discarded());
+
+    std::vector<const json*> all;
+    collect_json_elements(tree["root"], all);
+    const json* target = nullptr;
+    for (const auto* element : all) {
+        if (uia_prop(*element, "IsControlElement") == "false" &&
+            !uia_prop(*element, "RuntimeId").empty()) {
+            target = element;
+            break;
+        }
+    }
+    if (!target)
+        GTEST_SKIP() << "this Notepad build exposes no raw-view-only elements";
+
+    const auto ref = "uia:" + uia_prop(*target, "RuntimeId");
+    auto result = run_action_json(lvt, get_pid_arg() + " focus " + ref + " --uia-view raw");
+    EXPECT_EQ(result.value("error", "").find("could not be located"), std::string::npos)
+        << "a raw-view element the walk emitted must be resolvable for actions: " << result.dump(2);
+}
+
+TEST_F(NotepadFixture, WindowVerbsStillWorkOnTheWindowElement) {
+    // The guard added above must not break the legitimate case it guards.
+    auto lvt = get_lvt_path();
+
+    auto result = run_action_json(lvt, get_pid_arg() + " minimize");
+    ASSERT_TRUE(result.value("ok", false)) << result.dump(2);
+    Sleep(600);
+    EXPECT_TRUE(IsIconic(s_hwnd));
+
+    auto restored = run_action_json(lvt, get_pid_arg() + " restore");
+    EXPECT_TRUE(restored.value("ok", false)) << restored.dump(2);
+    Sleep(600);
+    EXPECT_FALSE(IsIconic(s_hwnd));
+}
+
+TEST_F(NotepadFixture, EveryActionReportsItsOwnNameNotUnknown) {
+    auto lvt = get_lvt_path();
+
+    // Nine of the twenty action kinds had no name and reported themselves as
+    // "unknown" in the result JSON, which made results impossible to correlate
+    // with the command that produced them. These four were among them, and are
+    // reachable without needing a particular control to exist.
+    const std::pair<std::string, std::string> cases[] = {
+        {"restore", "restore"},
+        {"maximize", "maximize"},
+        {"minimize", "minimize"},
+        {"wait-gone uia:99.99.99 --wait-timeout 500", "wait-gone"},
+    };
+    for (const auto& [command, expected] : cases) {
+        auto result = run_action_json(lvt, get_pid_arg() + " " + command);
+        EXPECT_EQ(result.value("action", ""), expected)
+            << "command '" << command << "' reported the wrong action: " << result.dump(2);
+    }
+    run_action_json(lvt, get_pid_arg() + " restore");
+}
+
+TEST_F(NotepadFixture, WaitGoneSucceedsWhenTheWindowItselfCloses) {
+    auto lvt = get_lvt_path();
+
+    // `close` then `wait-gone` is the natural pairing, and it used to time out:
+    // once the window was destroyed the tree could not be built, so the
+    // satisfied-check never ran and the wait reported failure for exactly the
+    // outcome it was waiting for.
+    //
+    // The window under test is one this test owns and destroys. Launching a
+    // second Notepad and killing it is not an option: modern Notepad serves
+    // every window from one process, so terminating it would take the shared
+    // fixture window with it.
+    static constexpr wchar_t kClassName[] = L"LvtWaitGoneProbe";
+    wil::unique_event ready(wil::EventOptions::ManualReset);
+    wil::unique_event destroy(wil::EventOptions::ManualReset);
+    HWND probe = nullptr;
+
+    std::thread ui([&] {
+        WNDCLASSEXW wc{sizeof(wc)};
+        wc.lpfnWndProc = DefWindowProcW;
+        wc.hInstance = GetModuleHandleW(nullptr);
+        wc.lpszClassName = kClassName;
+        RegisterClassExW(&wc);
+
+        probe = CreateWindowExW(0, kClassName, L"lvt wait-gone probe",
+                                WS_OVERLAPPEDWINDOW | WS_VISIBLE, 100, 100, 400, 300,
+                                nullptr, nullptr, wc.hInstance, nullptr);
+        ready.SetEvent();
+        if (!probe)
+            return;
+
+        // UIA reads this window cross-process, so it has to be pumping messages
+        // the whole time lvt is looking at it.
+        for (;;) {
+            MSG msg;
+            while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+                TranslateMessage(&msg);
+                DispatchMessageW(&msg);
+            }
+            if (destroy.wait(20))
+                break;
+        }
+        DestroyWindow(probe);
+        // Let the destruction actually complete before the thread exits.
+        MSG msg;
+        while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+            TranslateMessage(&msg);
+            DispatchMessageW(&msg);
+        }
+    });
+    auto joinUi = wil::scope_exit([&] {
+        destroy.SetEvent();
+        if (ui.joinable())
+            ui.join();
+    });
+
+    ASSERT_TRUE(ready.wait(5000)) << "the probe window thread never started";
+    ASSERT_NE(probe, nullptr) << "could not create the probe window";
+
+    char hwndArg[64];
+    snprintf(hwndArg, sizeof(hwndArg), "--hwnd 0x%llX",
+             static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(probe)));
+
+    auto probeTree = json::parse(
+        run_command(make_cmd(lvt, std::string(hwndArg) + " dump --uia")), nullptr, false);
+    ASSERT_FALSE(probeTree.is_discarded()) << "could not read the probe window's UIA tree";
+    const auto probeRef = "uia:" + uia_prop(probeTree["root"], "RuntimeId");
+    ASSERT_NE(probeRef, "uia:");
+
+    destroy.SetEvent();
+    ui.join();
+    for (int i = 0; i < 50 && IsWindow(probe); ++i)
+        Sleep(100);
+    ASSERT_FALSE(IsWindow(probe)) << "the probe window did not go away";
+
+    const auto start = GetTickCount64();
+    auto result = run_action_json(
+        lvt, std::string(hwndArg) + " wait-gone " + probeRef + " --wait-timeout 8000");
+    const auto elapsed = GetTickCount64() - start;
+
+    EXPECT_TRUE(result.value("ok", false))
+        << "wait-gone must succeed once the window is destroyed: " << result.dump(2);
+    EXPECT_LT(elapsed, 7000u) << "wait-gone burned its timeout instead of noticing the closure";
+}
+
+TEST_F(NotepadFixture, SyntheticInputRefusesOffscreenTargets) {
+    auto lvt = get_lvt_path();
+
+    // Offscreen elements report coordinates far outside the desktop. The mouse
+    // APIs clamp such a point to the nearest edge and report success, so a
+    // click aimed at one used to be injected at the desktop corner — on some
+    // other window entirely — and reported as having worked.
+    auto tree = json::parse(
+        run_command(make_cmd(lvt, get_pid_arg() + " dump --uia --uia-view raw")), nullptr, false);
+    ASSERT_FALSE(tree.is_discarded());
+
+    std::vector<const json*> all;
+    collect_json_elements(tree["root"], all);
+    const json* offscreen = nullptr;
+    for (const auto* element : all) {
+        if (uia_prop(*element, "IsOffscreen") != "true")
+            continue;
+        if (uia_prop(*element, "RuntimeId").empty())
+            continue;
+        // Only elements with no quiet route reach the synthetic path.
+        const auto patterns = uia_prop(*element, "SupportedPatterns");
+        if (patterns.find("Invoke") != std::string::npos)
+            continue;
+        offscreen = element;
+        break;
+    }
+    if (!offscreen)
+        GTEST_SKIP() << "no offscreen element without an Invoke pattern to test with";
+
+    const auto ref = "uia:" + uia_prop(*offscreen, "RuntimeId");
+    auto result = run_action_json(lvt, get_pid_arg() + " click " + ref + " --uia-view raw");
+    EXPECT_FALSE(result.value("ok", true))
+        << "clicking an offscreen element must fail rather than click the desktop corner: "
+        << result.dump(2);
+}
+
+TEST_F(NotepadFixture, PackagedSkillMatchesTheRepositorySkill) {
+    // skills/lvt/SKILL.md is what plugin.json ships to consumers, while
+    // .github/skills/lvt/SKILL.md is what this repo's own agent reads. They had
+    // drifted far enough that the shipped copy documented flags which now exit
+    // 1, so the packaged skill actively told its reader to run broken commands.
+    const std::string root = LVT_SOURCE_DIR;
+    auto packaged = read_text_file(root + "\\skills\\lvt\\SKILL.md");
+    auto repository = read_text_file(root + "\\.github\\skills\\lvt\\SKILL.md");
+    ASSERT_FALSE(packaged.empty()) << "skills/lvt/SKILL.md is missing or empty";
+    ASSERT_FALSE(repository.empty()) << ".github/skills/lvt/SKILL.md is missing or empty";
+    EXPECT_EQ(packaged, repository)
+        << "the packaged skill has drifted from the repository skill; copy "
+           ".github/skills/lvt/SKILL.md over skills/lvt/SKILL.md";
+}
+
+TEST_F(NotepadFixture, NoSkillDocumentsRemovedFlags) {
+    // The flags below became verbs, so a doc that still shows them tells the
+    // reader to run something that exits 1.
+    const std::string root = LVT_SOURCE_DIR;
+    for (const char* relative : {"\\skills\\lvt\\SKILL.md", "\\.github\\skills\\lvt\\SKILL.md"}) {
+        const auto text = read_text_file(root + relative);
+        ASSERT_FALSE(text.empty()) << relative;
+        for (const char* removed : {"--dump", "--frameworks", "--click ", "--invoke "}) {
+            EXPECT_EQ(text.find(removed), std::string::npos)
+                << relative << " still documents the removed flag " << removed;
+        }
+    }
+}
+
 TEST_F(WinUI3SampleFixture, WaitGoneSucceedsForAnElementThatNeverExisted) {
     SkipIfNotReady();
     auto lvt = get_lvt_path();
@@ -2920,8 +3225,15 @@ TEST_F(NotepadFixture, LegacyFlagsReportTheirReplacement) {
         auto output = run_command(make_cmd(lvt, get_pid_arg() + " " + c.flag) + " 2>&1");
         EXPECT_NE(output.find("is now"), std::string::npos)
             << c.flag << " should report its replacement, got:\n" << output;
-        EXPECT_NE(output.find(c.expect), std::string::npos)
-            << c.flag << " should name the '" << c.expect << "' verb";
+        // Asserting the verb name alone is tautological — every one of these is
+        // a substring of the flag being echoed back, so it would pass for any
+        // message that merely repeated the input. Requiring the verb to appear
+        // *after* "is now" is what actually pins the replacement being named.
+        const auto isNow = output.find("is now");
+        ASSERT_NE(isNow, std::string::npos);
+        EXPECT_NE(output.find(c.expect, isNow), std::string::npos)
+            << c.flag << " should name the '" << c.expect << "' verb as its replacement, got:\n"
+            << output;
     }
 }
 
@@ -2948,6 +3260,21 @@ TEST_F(NotepadFixture, ScreenshotVerbDefaultsAndHonoursOutput) {
     run_command(make_cmd(lvt, get_pid_arg() + " screenshot --output " + tmpFile.string()));
     EXPECT_TRUE(fs::exists(tmpFile)) << "--output should name the PNG for the screenshot verb";
     fs::remove(tmpFile);
+
+    // The other half of this test's name: with no --output the verb writes
+    // lvt-screenshot.png in the working directory. Run from a scratch directory
+    // so the default cannot be confused with a leftover file.
+    const auto scratch = fs::temp_directory_path() / "lvt_screenshot_default";
+    std::error_code ec;
+    fs::remove_all(scratch, ec);
+    fs::create_directories(scratch, ec);
+    const auto defaultShot = scratch / "lvt-screenshot.png";
+
+    run_command("cd /d \"" + scratch.string() + "\" && " +
+                make_cmd(lvt, get_pid_arg() + " screenshot"));
+    EXPECT_TRUE(fs::exists(defaultShot))
+        << "screenshot with no --output should write lvt-screenshot.png";
+    fs::remove_all(scratch, ec);
 }
 
 TEST_F(WinUI3SampleFixture, UiaReferenceImpliesTheUiaTree) {

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -186,7 +186,7 @@ TEST_F(NotepadFixture, TargetInfo) {
 
 TEST_F(NotepadFixture, FrameworkDetection) {
     auto lvt = get_lvt_path();
-    auto output = run_command(make_cmd(lvt, get_pid_arg() + " --frameworks"));
+    auto output = run_command(make_cmd(lvt, get_pid_arg() + " frameworks"));
     ASSERT_FALSE(output.empty());
     // Notepad should at least have win32
     EXPECT_NE(output.find("win32"), std::string::npos);
@@ -245,10 +245,10 @@ TEST_F(NotepadFixture, ScreenshotCapture) {
     fs::remove(tmpFile);
 
     auto output = run_command(make_cmd(lvt,
-        get_pid_arg() + " --screenshot " + tmpFile.string()));
+        get_pid_arg() + " screenshot --output " + tmpFile.string()));
 
-    // --screenshot without --dump should produce no stdout
-    EXPECT_TRUE(output.empty()) << "stdout should be empty with --screenshot only";
+    // the screenshot verb writes a PNG, not a tree, so stdout stays empty
+    EXPECT_TRUE(output.empty()) << "the screenshot verb should not write a tree to stdout";
     // File should exist and be a valid PNG
     EXPECT_TRUE(fs::exists(tmpFile)) << "Screenshot file was not created";
     if (fs::exists(tmpFile)) {
@@ -266,23 +266,23 @@ TEST_F(NotepadFixture, ScreenshotCapture) {
     fs::remove(tmpFile);
 }
 
-TEST_F(NotepadFixture, ScreenshotWithDump) {
+TEST_F(NotepadFixture, ScreenshotAndDumpAreSeparateInvocations) {
+    // `--screenshot <file> --dump` used to do both at once. Splitting the verbs
+    // makes that two commands, which is the trade for each verb having one job.
     auto lvt = get_lvt_path();
     auto tmpFile = fs::path(lvt).parent_path() / "lvt_test_both.png";
     fs::remove(tmpFile);
 
-    auto output = run_command(make_cmd(lvt,
-        get_pid_arg() + " --screenshot " + tmpFile.string() + " --dump"));
-
-    // Should have both tree output and screenshot file
-    EXPECT_FALSE(output.empty()) << "stdout should have tree output with --dump";
-    EXPECT_TRUE(fs::exists(tmpFile)) << "Screenshot file was not created";
-
-    if (!output.empty()) {
-        auto j = json::parse(output, nullptr, false);
-        EXPECT_FALSE(j.is_discarded()) << "stdout should be valid JSON";
-    }
+    auto shot = run_command(make_cmd(lvt,
+        get_pid_arg() + " screenshot --output " + tmpFile.string()));
+    EXPECT_TRUE(shot.empty()) << "the screenshot verb should not write a tree to stdout";
+    ASSERT_TRUE(fs::exists(tmpFile)) << "Screenshot file was not created";
     fs::remove(tmpFile);
+
+    auto dumped = run_command(make_cmd(lvt, get_pid_arg() + " dump"));
+    ASSERT_FALSE(dumped.empty()) << "the dump verb should write a tree to stdout";
+    auto j = json::parse(dumped, nullptr, false);
+    EXPECT_FALSE(j.is_discarded()) << "stdout should be valid JSON";
 }
 
 TEST_F(NotepadFixture, OutputToFile) {
@@ -551,7 +551,7 @@ static json query_element_until(const std::string& lvt, const std::string& pidAr
                                 int attempts = 40) {
     json q;
     for (int i = 0; i < attempts; ++i) {
-        auto out = run_command(make_cmd(lvt, pidArg + " --query " + cmd_escape_arg(ref)));
+        auto out = run_command(make_cmd(lvt, pidArg + " query " + cmd_escape_arg(ref)));
         q = json::parse(out, nullptr, false);
         if (!q.is_discarded() && q.value("key", "") == expectedKey)
             return q;
@@ -566,7 +566,7 @@ static std::string query_prop_until(const std::string& lvt, const std::string& p
                                     const std::string& expected, int attempts = 40) {
     std::string r;
     for (int i = 0; i < attempts; ++i) {
-        r = trim_crlf(run_command(make_cmd(lvt, pidArg + " --query " + cmd_escape_arg(ref) + " " + prop)));
+        r = trim_crlf(run_command(make_cmd(lvt, pidArg + " query " + cmd_escape_arg(ref) + " " + prop)));
         if (r == expected)
             return r;
         Sleep(500);
@@ -845,7 +845,7 @@ TEST_F(WinFormsSampleFixture, DetectsWinFormsFramework) {
     SkipIfNotReady();
 
     auto lvt = get_lvt_path();
-    auto output = run_command(make_cmd(lvt, get_pid_arg() + " --frameworks"));
+    auto output = run_command(make_cmd(lvt, get_pid_arg() + " frameworks"));
     ASSERT_FALSE(output.empty());
     EXPECT_NE(output.find("winforms"), std::string::npos);
 }
@@ -1275,10 +1275,10 @@ TEST_F(NotepadFixture, QueryByIdAndDurableKey) {
     auto rootKey = j["root"].value("key", "");
     ASSERT_FALSE(rootKey.empty());
 
-    auto byId = run_command(make_cmd(lvt, get_pid_arg() + " --query e0 type"));
+    auto byId = run_command(make_cmd(lvt, get_pid_arg() + " query e0 type"));
     EXPECT_EQ(trim_crlf(byId), j["root"].value("type", ""));
 
-    auto byKey = run_command(make_cmd(lvt, get_pid_arg() + " --query " + cmd_escape_arg(rootKey) + " id"));
+    auto byKey = run_command(make_cmd(lvt, get_pid_arg() + " query " + cmd_escape_arg(rootKey) + " id"));
     EXPECT_EQ(trim_crlf(byKey), "e0");
 }
 
@@ -1329,7 +1329,7 @@ TEST_F(NotepadFixture, AnnotationsMatchTreeElements) {
     fs::remove(annFile);
 
     auto output = run_command(make_cmd(lvt,
-        get_pid_arg() + " --dump --annotations-json " + annFile.string()));
+        get_pid_arg() + " dump --annotations-json " + annFile.string()));
 
     auto tree = json::parse(output, nullptr, false);
     ASSERT_FALSE(tree.is_discarded());
@@ -1565,7 +1565,7 @@ protected:
 
 TEST_F(ComCtlWindowFixture, DetectsComCtlAndEnrichesItems) {
     auto lvt = get_lvt_path();
-    auto fwOutput = run_command(make_cmd(lvt, get_hwnd_arg() + " --frameworks"));
+    auto fwOutput = run_command(make_cmd(lvt, get_hwnd_arg() + " frameworks"));
     ASSERT_FALSE(fwOutput.empty());
     EXPECT_NE(fwOutput.find("win32"), std::string::npos);
     EXPECT_NE(fwOutput.find("comctl"), std::string::npos);
@@ -1645,7 +1645,7 @@ TEST_F(ComCtlWindowFixture, DurableKeysCoverFullStaticTreeAndQueryRoundTrips) {
     auto key = item->value("key", "");
     ASSERT_FALSE(key.empty());
 
-    auto byKey = run_command(make_cmd(lvt, get_hwnd_arg() + " --query " + cmd_escape_arg(key) + " index"));
+    auto byKey = run_command(make_cmd(lvt, get_hwnd_arg() + " query " + cmd_escape_arg(key) + " index"));
     EXPECT_EQ(trim_crlf(byKey), "0");
 }
 
@@ -1654,7 +1654,7 @@ TEST_F(ComCtlWindowFixture, DurableKeysCoverFullStaticTreeAndQueryRoundTrips) {
 TEST_F(NotepadFixture, WinUI3BoundsIfDetected) {
     // If WinUI3 framework is detected, verify XAML element bounds are reasonable
     auto lvt = get_lvt_path();
-    auto fwOutput = run_command(make_cmd(lvt, get_pid_arg() + " --frameworks"));
+    auto fwOutput = run_command(make_cmd(lvt, get_pid_arg() + " frameworks"));
     if (fwOutput.find("winui3") == std::string::npos) {
         GTEST_SKIP() << "WinUI3 not detected for this Notepad instance";
     }
@@ -1696,7 +1696,7 @@ TEST_F(NotepadFixture, WinUI3BoundsIfDetected) {
 TEST_F(NotepadFixture, XamlBoundsIfDetected) {
     // If XAML framework is detected (UWP), verify element bounds are reasonable
     auto lvt = get_lvt_path();
-    auto fwOutput = run_command(make_cmd(lvt, get_pid_arg() + " --frameworks"));
+    auto fwOutput = run_command(make_cmd(lvt, get_pid_arg() + " frameworks"));
     if (fwOutput.find("xaml") == std::string::npos) {
         GTEST_SKIP() << "XAML (UWP) not detected for this Notepad instance";
     }
@@ -1890,7 +1890,7 @@ TEST_F(KnownWindowFixture, AnnotationsIncludeKnownControls) {
     fs::remove(annFile);
 
     auto output = run_command(make_cmd(lvt,
-        get_hwnd_arg() + " --dump --annotations-json " + annFile.string()));
+        get_hwnd_arg() + " dump --annotations-json " + annFile.string()));
     auto tree = json::parse(output, nullptr, false);
     ASSERT_FALSE(tree.is_discarded());
 
@@ -2078,7 +2078,7 @@ TEST_F(WinUI3SampleFixture, UiaElementsCarryDurableKeysAndResolveByRuntimeId) {
     ASSERT_FALSE(runtimeId.empty());
 
     auto queried = run_command(make_cmd(
-        lvt, get_pid_arg() + " --uia --query uia:" + runtimeId + " AutomationId"));
+        lvt, get_pid_arg() + " query uia:" + runtimeId + " AutomationId"));
     // Trim the trailing newline the CLI writes.
     while (!queried.empty() && (queried.back() == '\n' || queried.back() == '\r'))
         queried.pop_back();
@@ -2163,7 +2163,7 @@ TEST_F(WinUI3SampleFixture, UiaTreeDrivesScreenshotAnnotations) {
     fs::remove(annFile);
 
     run_command(make_cmd(lvt,
-        get_pid_arg() + " --uia --dump --annotations-json " + annFile.string()));
+        get_pid_arg() + " dump --uia --annotations-json " + annFile.string()));
 
     ASSERT_TRUE(fs::exists(annFile)) << "no annotations produced for a UIA tree";
     std::string content;
@@ -2234,7 +2234,7 @@ TEST_F(WinUI3SampleFixture, UiaWatchEmitsAddedEvents) {
     PROCESS_INFORMATION pi{};
 
     auto lvt = get_lvt_path();
-    std::string cmd = make_cmd(lvt, get_pid_arg() + " --uia --watch --interval 500");
+    std::string cmd = make_cmd(lvt, get_pid_arg() + " watch --uia --interval 500");
     ASSERT_TRUE(CreateProcessA(nullptr, cmd.data(), nullptr, nullptr, TRUE,
                                CREATE_NO_WINDOW, nullptr, nullptr, &si, &pi));
     wil::unique_handle process(pi.hProcess);
@@ -2500,4 +2500,200 @@ TEST_F(WinUI3SampleFixture, UiaEmitsEnumNamesNotRawNumbers) {
         }
     }
     EXPECT_GT(checked, 0) << "no enum-valued properties were present to check";
+}
+
+// --- Interaction verbs ---
+// These assert that lvt actually drives the app, not merely that a command
+// returned success: each checks an observable change in the target's own tree.
+
+namespace {
+
+json run_action_json(const std::string& lvt, const std::string& args) {
+    auto output = run_command(make_cmd(lvt, args));
+    auto j = json::parse(output, nullptr, false);
+    EXPECT_FALSE(j.is_discarded()) << "action produced no JSON:\n" << output;
+    return j;
+}
+
+// Read one AutomationId's element out of a fresh UIA walk.
+json uia_element(const std::string& lvt, const std::string& pidArg,
+                 const std::string& automationId) {
+    auto tree = json::parse(run_command(make_cmd(lvt, pidArg + " dump --uia")), nullptr, false);
+    if (tree.is_discarded() || !tree.contains("root"))
+        return json();
+    const json* found = find_by_automation_id(tree["root"], automationId);
+    return found ? *found : json();
+}
+
+} // namespace
+
+TEST_F(WinUI3SampleFixture, ClickInvokesThroughAPatternAndChangesTheApp) {
+    SkipIfNotReady();
+    auto lvt = get_lvt_path();
+
+    const auto before = uia_element(lvt, get_pid_arg(), "StatusText");
+    ASSERT_FALSE(before.is_null());
+    const auto beforeText = before.value("text", "");
+    ASSERT_FALSE(beforeText.empty());
+
+    auto button = uia_element(lvt, get_pid_arg(), "PrimaryButton");
+    ASSERT_FALSE(button.is_null());
+    const auto ref = "uia:" + uia_prop(button, "RuntimeId");
+
+    auto result = run_action_json(lvt, get_pid_arg() + " click " + ref);
+    EXPECT_TRUE(result.value("ok", false)) << result.dump(2);
+    // A button exposes Invoke, so this must not fall back to synthetic input:
+    // the pattern route neither steals focus nor moves the cursor.
+    EXPECT_EQ(result.value("method", ""), "InvokePattern");
+
+    const auto after = uia_element(lvt, get_pid_arg(), "StatusText");
+    ASSERT_FALSE(after.is_null());
+    EXPECT_NE(after.value("text", ""), beforeText)
+        << "the click reported success but the app did not react";
+}
+
+TEST_F(WinUI3SampleFixture, ToggleFlipsCheckboxState) {
+    SkipIfNotReady();
+    auto lvt = get_lvt_path();
+
+    auto before = uia_element(lvt, get_pid_arg(), "ReadyCheckBox");
+    ASSERT_FALSE(before.is_null());
+    const auto beforeState = uia_prop(before, "Toggle.ToggleState");
+    ASSERT_FALSE(beforeState.empty());
+    const auto ref = "uia:" + uia_prop(before, "RuntimeId");
+
+    auto result = run_action_json(lvt, get_pid_arg() + " toggle " + ref);
+    EXPECT_TRUE(result.value("ok", false)) << result.dump(2);
+    EXPECT_EQ(result.value("method", ""), "TogglePattern");
+
+    auto after = uia_element(lvt, get_pid_arg(), "ReadyCheckBox");
+    ASSERT_FALSE(after.is_null());
+    EXPECT_NE(uia_prop(after, "Toggle.ToggleState"), beforeState);
+
+    // Put it back, so the ordering of tests in this fixture does not matter.
+    run_command(make_cmd(lvt, get_pid_arg() + " toggle " + ref));
+}
+
+TEST_F(WinUI3SampleFixture, SetValueWritesThroughTheValuePattern) {
+    SkipIfNotReady();
+    auto lvt = get_lvt_path();
+
+    auto box = uia_element(lvt, get_pid_arg(), "InputBox");
+    ASSERT_FALSE(box.is_null());
+    const auto ref = "uia:" + uia_prop(box, "RuntimeId");
+    const auto original = uia_prop(box, "Value.Value");
+
+    auto result = run_action_json(lvt,
+        get_pid_arg() + " set-value " + ref + " written-by-a-test");
+    EXPECT_TRUE(result.value("ok", false)) << result.dump(2);
+    EXPECT_EQ(result.value("method", ""), "ValuePattern");
+
+    auto after = uia_element(lvt, get_pid_arg(), "InputBox");
+    ASSERT_FALSE(after.is_null());
+    EXPECT_EQ(uia_prop(after, "Value.Value"), "written-by-a-test");
+
+    // Restore, so this fixture's tests do not depend on running order.
+    if (!original.empty())
+        run_command(make_cmd(lvt, get_pid_arg() + " set-value " + ref + " " +
+                                      cmd_escape_arg(original)));
+}
+
+TEST_F(WinUI3SampleFixture, ActionResultReportsHowItWasPerformed) {
+    SkipIfNotReady();
+    auto lvt = get_lvt_path();
+
+    // A caller needs to distinguish a quiet pattern call from synthetic input,
+    // because only the latter steals focus and depends on window ordering.
+    auto button = uia_element(lvt, get_pid_arg(), "PrimaryButton");
+    ASSERT_FALSE(button.is_null());
+    const auto ref = "uia:" + uia_prop(button, "RuntimeId");
+
+    auto viaPattern = run_action_json(lvt, get_pid_arg() + " click " + ref);
+    EXPECT_EQ(viaPattern.value("method", ""), "InvokePattern");
+
+    // double-click has no pattern equivalent, so it must say it used SendInput
+    // rather than quietly invoking once and claiming success.
+    auto viaInput = run_action_json(lvt, get_pid_arg() + " double-click " + ref);
+    EXPECT_TRUE(viaInput.value("ok", false)) << viaInput.dump(2);
+    EXPECT_EQ(viaInput.value("method", ""), "SendInput");
+}
+
+TEST_F(WinUI3SampleFixture, InvokeRefusesElementsWithoutThePattern) {
+    SkipIfNotReady();
+    auto lvt = get_lvt_path();
+
+    auto check = uia_element(lvt, get_pid_arg(), "ReadyCheckBox");
+    ASSERT_FALSE(check.is_null());
+    const auto ref = "uia:" + uia_prop(check, "RuntimeId");
+
+    // A checkbox toggles, it does not invoke. The strict verb must say so
+    // rather than falling back to a click that happens to work.
+    auto result = run_action_json(lvt, get_pid_arg() + " invoke " + ref);
+    EXPECT_FALSE(result.value("ok", true));
+    EXPECT_NE(result.value("error", "").find("Invoke"), std::string::npos)
+        << result.dump(2);
+}
+
+TEST_F(WinUI3SampleFixture, WindowVerbsChangeVisualState) {
+    SkipIfNotReady();
+    auto lvt = get_lvt_path();
+
+    auto minimized = run_action_json(lvt, get_pid_arg() + " minimize");
+    EXPECT_TRUE(minimized.value("ok", false)) << minimized.dump(2);
+    EXPECT_NE(minimized.value("method", "").find("WindowPattern"), std::string::npos);
+
+    auto restored = run_action_json(lvt, get_pid_arg() + " restore");
+    EXPECT_TRUE(restored.value("ok", false)) << restored.dump(2);
+
+    auto tree = json::parse(run_command(make_cmd(lvt, get_pid_arg() + " dump --uia")),
+                            nullptr, false);
+    ASSERT_FALSE(tree.is_discarded());
+    EXPECT_EQ(uia_prop(tree["root"], "Window.WindowVisualState"), "Normal");
+}
+
+TEST_F(WinUI3SampleFixture, WaitForReturnsImmediatelyWhenSatisfied) {
+    SkipIfNotReady();
+    auto lvt = get_lvt_path();
+
+    auto check = uia_element(lvt, get_pid_arg(), "ReadyCheckBox");
+    ASSERT_FALSE(check.is_null());
+    const auto ref = "uia:" + uia_prop(check, "RuntimeId");
+    const auto state = uia_prop(check, "Toggle.ToggleState");
+
+    auto present = run_action_json(lvt, get_pid_arg() + " wait-for " + ref);
+    EXPECT_TRUE(present.value("ok", false)) << present.dump(2);
+
+    auto withProp = run_action_json(lvt,
+        get_pid_arg() + " wait-for " + ref + " --wait-prop Toggle.ToggleState=" + state);
+    EXPECT_TRUE(withProp.value("ok", false)) << withProp.dump(2);
+}
+
+TEST_F(WinUI3SampleFixture, WaitForTimesOutWithAnActionableMessage) {
+    SkipIfNotReady();
+    auto lvt = get_lvt_path();
+
+    auto check = uia_element(lvt, get_pid_arg(), "ReadyCheckBox");
+    ASSERT_FALSE(check.is_null());
+    const auto ref = "uia:" + uia_prop(check, "RuntimeId");
+
+    const auto start = GetTickCount64();
+    auto result = run_action_json(lvt, get_pid_arg() + " wait-for " + ref +
+        " --wait-prop Toggle.ToggleState=Indeterminate --wait-timeout 900");
+    const auto elapsed = GetTickCount64() - start;
+
+    EXPECT_FALSE(result.value("ok", true));
+    EXPECT_NE(result.value("error", "").find("timed out"), std::string::npos)
+        << result.dump(2);
+    // It must actually wait rather than returning at once, and must not hang.
+    EXPECT_GE(elapsed, 800u);
+    EXPECT_LT(elapsed, 20000u);
+}
+
+TEST_F(WinUI3SampleFixture, ActionsReportFailureForUnknownElements) {
+    SkipIfNotReady();
+    auto lvt = get_lvt_path();
+
+    auto result = run_action_json(lvt, get_pid_arg() + " click uia:99.99.99");
+    EXPECT_FALSE(result.value("ok", true));
+    EXPECT_FALSE(result.value("error", "").empty());
 }

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -12,6 +12,8 @@
 #include "providers/winforms_inject.h"
 #include "providers/uia_provider.h"
 #include "providers/uia_props.h"
+#include "input.h"
+#include "providers/uia_actions.h"
 #include <oleacc.h>
 #include <UIAutomation.h>
 #include "wil_diagnostics.h"
@@ -1446,4 +1448,107 @@ TEST(FindElementByRef, NormalizesAndValidatesUiaReferences) {
     // the id/key lookups and matching something unrelated.
     EXPECT_EQ(lvt::find_element_by_ref(root, "uia:not-an-id"), nullptr);
     EXPECT_EQ(lvt::find_element_by_ref(root, "uia:"), nullptr);
+}
+
+// --- Key chord parsing ---
+// press-key is the one interaction with no UIA pattern behind it, so the chord
+// grammar is the whole contract.
+
+TEST(KeyChord, ParsesBareKeys) {
+    lvt::KeyChord chord;
+    ASSERT_TRUE(lvt::parse_key_chord("Enter", chord));
+    EXPECT_EQ(chord.vk, VK_RETURN);
+    EXPECT_FALSE(chord.ctrl || chord.alt || chord.shift || chord.win);
+
+    ASSERT_TRUE(lvt::parse_key_chord("escape", chord));
+    EXPECT_EQ(chord.vk, VK_ESCAPE);
+    ASSERT_TRUE(lvt::parse_key_chord("F5", chord));
+    EXPECT_EQ(chord.vk, VK_F5);
+    ASSERT_TRUE(lvt::parse_key_chord("f12", chord));
+    EXPECT_EQ(chord.vk, VK_F12);
+    ASSERT_TRUE(lvt::parse_key_chord("PageDown", chord));
+    EXPECT_EQ(chord.vk, VK_NEXT);
+}
+
+TEST(KeyChord, ParsesModifiers) {
+    lvt::KeyChord chord;
+    ASSERT_TRUE(lvt::parse_key_chord("Ctrl+S", chord));
+    EXPECT_TRUE(chord.ctrl);
+    EXPECT_FALSE(chord.alt);
+    EXPECT_NE(chord.vk, 0);
+
+    ASSERT_TRUE(lvt::parse_key_chord("ctrl+shift+alt+F4", chord));
+    EXPECT_TRUE(chord.ctrl);
+    EXPECT_TRUE(chord.shift);
+    EXPECT_TRUE(chord.alt);
+    EXPECT_EQ(chord.vk, VK_F4);
+
+    ASSERT_TRUE(lvt::parse_key_chord("Control+Home", chord));
+    EXPECT_TRUE(chord.ctrl);
+    EXPECT_EQ(chord.vk, VK_HOME);
+}
+
+TEST(KeyChord, ShiftedCharactersCarryTheirOwnModifier) {
+    // VkKeyScan reports the shift state a character needs, so an uppercase
+    // letter must not silently type a lowercase one.
+    lvt::KeyChord upper;
+    ASSERT_TRUE(lvt::parse_key_chord("A", upper));
+    lvt::KeyChord lower;
+    ASSERT_TRUE(lvt::parse_key_chord("a", lower));
+    EXPECT_EQ(upper.vk, lower.vk);
+    EXPECT_TRUE(upper.shift);
+    EXPECT_FALSE(lower.shift);
+}
+
+TEST(KeyChord, HandlesPlusAsAKey) {
+    // "Ctrl++" is a real accelerator (zoom in), and naive splitting on '+'
+    // turns it into a trailing empty token.
+    lvt::KeyChord chord;
+    ASSERT_TRUE(lvt::parse_key_chord("Ctrl++", chord));
+    EXPECT_TRUE(chord.ctrl);
+    EXPECT_NE(chord.vk, 0);
+}
+
+TEST(KeyChord, RejectsMalformedInput) {
+    lvt::KeyChord chord;
+    EXPECT_FALSE(lvt::parse_key_chord("", chord));
+    EXPECT_FALSE(lvt::parse_key_chord("   ", chord));
+    EXPECT_FALSE(lvt::parse_key_chord("Ctrl+", chord));
+    EXPECT_FALSE(lvt::parse_key_chord("Ctrl", chord));      // modifier with no key
+    EXPECT_FALSE(lvt::parse_key_chord("NotAKey", chord));
+    EXPECT_FALSE(lvt::parse_key_chord("F0", chord));
+    EXPECT_FALSE(lvt::parse_key_chord("F25", chord));
+    EXPECT_FALSE(lvt::parse_key_chord("Bogus+A", chord));   // unknown modifier
+}
+
+TEST(KeyChord, ParsesSequences) {
+    std::vector<lvt::KeyChord> chords;
+    ASSERT_TRUE(lvt::parse_key_chords("Ctrl+A;Delete", chords));
+    ASSERT_EQ(chords.size(), 2u);
+    EXPECT_TRUE(chords[0].ctrl);
+    EXPECT_EQ(chords[1].vk, VK_DELETE);
+
+    ASSERT_TRUE(lvt::parse_key_chords("Enter, Tab , Escape", chords));
+    ASSERT_EQ(chords.size(), 3u);
+    EXPECT_EQ(chords[0].vk, VK_RETURN);
+    EXPECT_EQ(chords[1].vk, VK_TAB);
+    EXPECT_EQ(chords[2].vk, VK_ESCAPE);
+
+    // One bad chord fails the whole sequence rather than silently sending part.
+    EXPECT_FALSE(lvt::parse_key_chords("Enter;NotAKey", chords));
+    EXPECT_FALSE(lvt::parse_key_chords("", chords));
+}
+
+TEST(ActionKind, ParsesAndRoundTripsNames) {
+    lvt::ActionKind kind;
+    ASSERT_TRUE(lvt::parse_action_kind("click", kind));
+    EXPECT_EQ(kind, lvt::ActionKind::click);
+    ASSERT_TRUE(lvt::parse_action_kind("set-value", kind));
+    EXPECT_EQ(kind, lvt::ActionKind::setValue);
+    ASSERT_TRUE(lvt::parse_action_kind("SetValue", kind));
+    EXPECT_EQ(kind, lvt::ActionKind::setValue);
+    EXPECT_FALSE(lvt::parse_action_kind("nonsense", kind));
+
+    EXPECT_STREQ(lvt::action_kind_name(lvt::ActionKind::click), "click");
+    EXPECT_STREQ(lvt::action_kind_name(lvt::ActionKind::setValue), "set-value");
 }

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -1476,6 +1476,10 @@ TEST(KeyChord, ParsesModifiers) {
     EXPECT_TRUE(chord.ctrl);
     EXPECT_FALSE(chord.alt);
     EXPECT_NE(chord.vk, 0);
+    // The case written by the caller must not become a Shift. Ctrl+S and
+    // Ctrl+Shift+S are different shortcuts in most applications, so folding
+    // VkKeyScan's case bit in here silently sends the wrong one.
+    EXPECT_FALSE(chord.shift) << "Ctrl+S must not become Ctrl+Shift+S";
 
     ASSERT_TRUE(lvt::parse_key_chord("ctrl+shift+alt+F4", chord));
     EXPECT_TRUE(chord.ctrl);
@@ -1486,6 +1490,79 @@ TEST(KeyChord, ParsesModifiers) {
     ASSERT_TRUE(lvt::parse_key_chord("Control+Home", chord));
     EXPECT_TRUE(chord.ctrl);
     EXPECT_EQ(chord.vk, VK_HOME);
+}
+
+TEST(SyntheticInput, PointIsOnScreenAcceptsTheDesktopAndRejectsOffscreenCoordinates) {
+    // The guard that stops a click aimed at an offscreen element from being
+    // clamped onto whatever sits at the desktop's corner. Offscreen XAML
+    // elements routinely report coordinates like -20237,-21283.
+    POINT onScreen{GetSystemMetrics(SM_CXSCREEN) / 2, GetSystemMetrics(SM_CYSCREEN) / 2};
+    EXPECT_TRUE(lvt::point_is_on_screen(onScreen));
+
+    EXPECT_FALSE(lvt::point_is_on_screen(POINT{-20237, -21283}));
+    EXPECT_FALSE(lvt::point_is_on_screen(POINT{1'000'000, 1'000'000}));
+}
+
+TEST(SyntheticInput, PointIsOnScreenAcceptsTheVirtualDesktopEdges) {
+    // Multi-monitor coordinates can legitimately be negative, so the check must
+    // be against the virtual desktop rather than the primary monitor.
+    const int left = GetSystemMetrics(SM_XVIRTUALSCREEN);
+    const int top = GetSystemMetrics(SM_YVIRTUALSCREEN);
+    const int width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+    const int height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+
+    EXPECT_TRUE(lvt::point_is_on_screen(POINT{left, top}));
+    EXPECT_TRUE(lvt::point_is_on_screen(POINT{left + width - 1, top + height - 1}));
+    // Just outside the virtual desktop must be rejected.
+    EXPECT_FALSE(lvt::point_is_on_screen(POINT{left + width + 500, top + height + 500}));
+}
+
+TEST(KeyChord, UppercaseLettersWithModifiersDoNotGainAPhantomShift) {    // Every one of these is a real, commonly used shortcut whose Shift variant
+    // does something different, which is what makes the bug this pins down
+    // more than cosmetic.
+    for (const char* text : {"Ctrl+S", "Ctrl+A", "Ctrl+N", "Ctrl+O", "Ctrl+W", "Alt+F"}) {
+        lvt::KeyChord chord;
+        ASSERT_TRUE(lvt::parse_key_chord(text, chord)) << text;
+        EXPECT_FALSE(chord.shift) << text << " must not imply Shift";
+    }
+
+    // The lowercase spelling has always been correct, and must stay identical
+    // to the uppercase one now that both are accepted.
+    lvt::KeyChord upper;
+    lvt::KeyChord lower;
+    ASSERT_TRUE(lvt::parse_key_chord("Ctrl+N", upper));
+    ASSERT_TRUE(lvt::parse_key_chord("Ctrl+n", lower));
+    EXPECT_EQ(upper.vk, lower.vk);
+    EXPECT_EQ(upper.shift, lower.shift);
+    EXPECT_EQ(upper.ctrl, lower.ctrl);
+}
+
+TEST(KeyChord, ExplicitShiftIsStillHonouredWithLetters) {
+    lvt::KeyChord chord;
+    ASSERT_TRUE(lvt::parse_key_chord("Ctrl+Shift+S", chord));
+    EXPECT_TRUE(chord.ctrl);
+    EXPECT_TRUE(chord.shift);
+
+    // Shift written on its own with a lowercase letter must still shift.
+    ASSERT_TRUE(lvt::parse_key_chord("Shift+a", chord));
+    EXPECT_TRUE(chord.shift);
+}
+
+TEST(KeyChord, PunctuationKeepsTheLayoutShiftEvenWithModifiers) {
+    // Unlike a letter's case, the Shift on punctuation is how the character is
+    // produced at all: dropping it would send Ctrl+/ instead of Ctrl+?. This is
+    // the distinction that stops the fix for the letter case from overreaching.
+    //
+    // Guarded on the layout actually needing Shift for '?', so the test does
+    // not fail on layouts where it does not.
+    const SHORT scan = VkKeyScanW(L'?');
+    if (scan == -1 || !((scan >> 8) & 1))
+        GTEST_SKIP() << "this keyboard layout does not reach '?' via Shift";
+
+    lvt::KeyChord chord;
+    ASSERT_TRUE(lvt::parse_key_chord("Ctrl+?", chord));
+    EXPECT_TRUE(chord.ctrl);
+    EXPECT_TRUE(chord.shift) << "punctuation must keep the shift that produces it";
 }
 
 TEST(KeyChord, ShiftedCharactersCarryTheirOwnModifier) {
@@ -1551,4 +1628,81 @@ TEST(ActionKind, ParsesAndRoundTripsNames) {
 
     EXPECT_STREQ(lvt::action_kind_name(lvt::ActionKind::click), "click");
     EXPECT_STREQ(lvt::action_kind_name(lvt::ActionKind::setValue), "set-value");
+}
+
+// Every ActionKind, so a new one cannot be added without a name. The previous
+// spot-check of two kinds let nine of them silently report themselves as
+// "unknown" in the result JSON.
+static constexpr lvt::ActionKind kAllActionKinds[] = {
+    lvt::ActionKind::click,          lvt::ActionKind::invoke,
+    lvt::ActionKind::toggle,         lvt::ActionKind::setValue,
+    lvt::ActionKind::expand,         lvt::ActionKind::collapse,
+    lvt::ActionKind::select,         lvt::ActionKind::addToSelection,
+    lvt::ActionKind::removeFromSelection, lvt::ActionKind::selectText,
+    lvt::ActionKind::focus,          lvt::ActionKind::scroll,
+    lvt::ActionKind::typeText,       lvt::ActionKind::pressKey,
+    lvt::ActionKind::windowClose,    lvt::ActionKind::windowMinimize,
+    lvt::ActionKind::windowMaximize, lvt::ActionKind::windowRestore,
+    lvt::ActionKind::waitFor,        lvt::ActionKind::waitGone,
+};
+
+TEST(ActionKind, EveryKindHasARealName) {
+    for (const auto kind : kAllActionKinds) {
+        const std::string name = lvt::action_kind_name(kind);
+        EXPECT_NE(name, "unknown")
+            << "ActionKind " << static_cast<int>(kind)
+            << " has no name, so it reports itself as \"unknown\" in the result JSON";
+        EXPECT_FALSE(name.empty());
+    }
+}
+
+TEST(ActionKind, EveryNameParsesBackToItsOwnKind) {
+    for (const auto kind : kAllActionKinds) {
+        const auto* name = lvt::action_kind_name(kind);
+        lvt::ActionKind parsed{};
+        ASSERT_TRUE(lvt::parse_action_kind(name, parsed))
+            << "'" << name << "' is emitted but not accepted back";
+        EXPECT_EQ(parsed, kind) << "'" << name << "' round-tripped to a different kind";
+    }
+}
+
+TEST(ActionKind, NamesAreUnique) {
+    // Two kinds sharing a name would make the round trip above pass while the
+    // reported action was still wrong for one of them.
+    std::set<std::string> seen;
+    for (const auto kind : kAllActionKinds) {
+        const std::string name = lvt::action_kind_name(kind);
+        EXPECT_TRUE(seen.insert(name).second) << "duplicate action name '" << name << "'";
+    }
+    EXPECT_EQ(seen.size(), std::size(kAllActionKinds));
+}
+
+TEST(ActionKind, CliVerbNamesMatchTheReportedActionNames) {
+    // The verb a user types and the action lvt reports having performed should
+    // be the same word; a mismatch makes result JSON hard to correlate with the
+    // command that produced it.
+    const std::pair<const char*, lvt::ActionKind> pairs[] = {
+        {"click", lvt::ActionKind::click},
+        {"invoke", lvt::ActionKind::invoke},
+        {"toggle", lvt::ActionKind::toggle},
+        {"set-value", lvt::ActionKind::setValue},
+        {"expand", lvt::ActionKind::expand},
+        {"collapse", lvt::ActionKind::collapse},
+        {"select", lvt::ActionKind::select},
+        {"add-to-selection", lvt::ActionKind::addToSelection},
+        {"remove-from-selection", lvt::ActionKind::removeFromSelection},
+        {"select-text", lvt::ActionKind::selectText},
+        {"focus", lvt::ActionKind::focus},
+        {"scroll", lvt::ActionKind::scroll},
+        {"type", lvt::ActionKind::typeText},
+        {"press-key", lvt::ActionKind::pressKey},
+        {"close", lvt::ActionKind::windowClose},
+        {"minimize", lvt::ActionKind::windowMinimize},
+        {"maximize", lvt::ActionKind::windowMaximize},
+        {"restore", lvt::ActionKind::windowRestore},
+        {"wait-for", lvt::ActionKind::waitFor},
+        {"wait-gone", lvt::ActionKind::waitGone},
+    };
+    for (const auto& [verb, kind] : pairs)
+        EXPECT_STREQ(lvt::action_kind_name(kind), verb);
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "lvt",
-  "version-string": "0.2.0",
+  "version-string": "0.3.0",
   "description": "Live Visual Tree - CLI tool for inspecting Windows app visual trees",
   "builtin-baseline": "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3",
   "dependencies": [


### PR DESCRIPTION
lvt could describe a UI but not touch it. `--uia` already reported which patterns an element supports, so the data needed to act was there — this adds the acting.

## CLI: verbs instead of flags

`lvt <verb> [arguments] [options]`, with `dump` implied when no verb is given, so `lvt --name notepad --format xml` is unchanged.

```bash
lvt --name notepad                        # dump is implied
lvt screenshot --pid 1234 --output out.png
lvt frameworks --hwnd 0x1A0B3C
lvt query e5 text --name myapp
lvt click e6 --name myapp
```

`--dump`, `--screenshot`, `--frameworks`, `--watch` and `--query` are now verbs, and the old flags fail with the replacement rather than "unknown argument":

```
$ lvt --pid 123 --frameworks
lvt: --frameworks is now the 'frameworks' verb: lvt frameworks --name <exe>
lvt: run 'lvt --help' for the full verb list
```

**Why now:** ~15 interaction flags were about to land. Mutually exclusive modes expressed as flags need a runtime check — I had literally written *"only one interaction flag can be used at a time"* — which positional verbs make impossible to violate. It also splits `--screenshot`'s two jobs: it meant both "write a PNG here" *and* "don't print a tree".

Bumped to **0.3.0**. The vcpkg port stays at 0.2.0 — it pins a released tarball and the release script updates it once a tag exists.

## Interaction

Patterns first, synthetic input only as fallback. A UIA pattern doesn't steal focus, doesn't move the cursor, and works when the window isn't on top.

| Verb | Pattern | Falls back to |
|---|---|---|
| `click` | `Invoke` → `LegacyIAccessible.DoDefaultAction` | synthetic click |
| `right-click` / `double-click` | — | always synthetic |
| `invoke` | `Invoke` only | fails instead |
| `toggle` / `expand` / `collapse` / `select` / `add-to-selection` / `remove-from-selection` | matching pattern | — |
| `set-value` | `Value` → `RangeValue` for numbers | focus + retype |
| `select-text` | `Text.FindText` + `Select` | — |
| `scroll` | `Scroll` → `ScrollItem` | wheel |
| `type` / `press-key` | — | synthetic; `--focus-first` to target |
| `close`/`minimize`/`maximize`/`restore` | `Window` | — |
| `wait-for` / `wait-gone` | polls a walk | — |

Three decisions worth review:

**`method` is reported in the result.** "Clicked it" and "moved the mouse and clicked where it was" are different promises. The result also carries the element *after* the action, so an effect is confirmable without a second walk, and failures distinguish a missing pattern from one that refused.

```json
{ "action": "click", "ok": true, "method": "InvokePattern",
  "result": { "AutomationId": "PrimaryButton", "...": "..." } }
```

**Virtualized items are realized automatically.** An item in a long list has no element until then — without this, interaction would work on toy UIs and fail on real ones.

**No repeat count.** Only OS-interpreted sequences need precise timing, and those are their own verbs, so repeating an action is repeating the command. Documented with the caveat that `eN` is *positional*: when repeating against content that changes shape (scrolling a virtualized list), address by durable key or `uia:<RuntimeId>`.

Also: a `uia:<RuntimeId>` reference now implies `--uia`, since it cannot resolve in the visual tree and would otherwise report a confusing "not found".

## Tests found two real parser bugs

The chord grammar is the entire contract for `press-key`, and testing it properly caught:

- `"Ctrl++"` (zoom in) **failed to parse**
- `"Ctrl+"` was **accepted** as the `+` key rather than rejected as a dangling separator

Both from treating a trailing `+` as a key. The key is now peeled off first and the remainder split as modifiers.

Interaction tests assert **observable change in the target**, not a success code — clicking increments a counter, toggling flips `Toggle.ToggleState`, `set-value` changes `Value.Value`. They also assert the *route taken*, so a regression that silently fell back to synthetic input fails the test. The WinUI3 sample gained a click handler and status label, because a click on a handler-less button has no effect a walk can see.

| Suite | Before | After |
|---|---|---|
| unit | 95 | **102** |
| integration | 44 | **53** (52 passed, 1 pre-existing skip) |
